### PR TITLE
SP2 / HE & KoE Legendary Characters / names correction

### DIFF
--- a/WDS/Highborn Elves/profiles.json
+++ b/WDS/Highborn Elves/profiles.json
@@ -1739,7 +1739,7 @@
     }
   },
   {
-    "Id": "e7d9f1b6a8c2d3a9f4e5b7a6d",
+    "Id": "d7d9f1b6a8c2d3a9f4e5b7a6d",
     "Name": "Master Acadnath, the Asfad Scholar",
     "Attributes": {},
     "AttributeLists": {},
@@ -1774,7 +1774,7 @@
        }
       },
       {
-        "Name": "Master Acadnath, the Asfad Scholar",
+        "Name": "Master Acadnath",
         "Values": {
           "HP": "3",
           "Df": "5",
@@ -1804,7 +1804,7 @@
     }
   },
   {
-    "Id": "e7d9f1b6a8c2d3a9f4e5b7a6d1",
+    "Id": "e7d9f1b6a8c2d3a9f4e5b7a6e",
     "Name": "Tenacla and Baluruth",
     "Attributes": {},
     "AttributeLists": {},

--- a/WDS/Highborn Elves/units.json
+++ b/WDS/Highborn Elves/units.json
@@ -110,7 +110,7 @@
   },
   {
     "Id": "a2b5e7d3f9c1b4a6d8e2f0c5a",
-    "Name": "Master Acadnath, the Scholar",
+    "Name": "Master Acadnath, the Asfad Scholar",
     "Attributes": {
       "totalCost": "700",
       "category": "Characters",
@@ -125,7 +125,7 @@
     "RuleIds": {},
     "OptionListIds": [],
     "ProfileIds": [
-      "e7d9f1b6a8c2d3a9f4e5b7a6d"
+      "d7d9f1b6a8c2d3a9f4e5b7a6d"
     ]
   },
   {
@@ -145,7 +145,7 @@
     "RuleIds": {},
     "OptionListIds": [],
     "ProfileIds": [
-      "e7d9f1b6a8c2d3a9f4e5b7a6d1"
+      "e7d9f1b6a8c2d3a9f4e5b7a6e"
     ]
   },  
   {

--- a/WDS/Kingdom of Equitaine/profiles.json
+++ b/WDS/Kingdom of Equitaine/profiles.json
@@ -1853,7 +1853,7 @@
   },
   {
     "Id": "a2b4c9d5e7f8a3d6b2c9e4f7a",
-    "Name": "King Henry the Young",
+    "Name": "King Henry",
     "Attributes": {},
     "AttributeLists": {},
     "RuleIds": {
@@ -1870,7 +1870,7 @@
     "OptionListIds": [],
     "Statlines": [
       {
-        "Name": "King Henry the Young",
+        "Name": "King Henry",
         "Values": {
           "Ad": "8",
           "Ma": "8",

--- a/WDS/Kingdom of Equitaine/units.json
+++ b/WDS/Kingdom of Equitaine/units.json
@@ -133,7 +133,7 @@
   },
   {
     "Id": "a4d3f8b2c9e1a7d4b3c5e9a2f",
-    "Name": "King Henry the Young",
+    "Name": "King Henry",
     "Attributes": {
       "totalCost": "650",
       "category": "Characters",


### PR DESCRIPTION
In reference to yesterday's comments in issue: #13

Both **HE** & **KoE** Legendary Characters names have been corrected.

Please review PR and Merge to 'main' branch.