### PR TITLE
AB - units profiles update - DE + VS - corrections

### DIFF
--- a/WDS/Dread Elves/options.json
+++ b/WDS/Dread Elves/options.json
@@ -283,7 +283,7 @@
     "Id": "f3a9c6b1-7e42-4d8a-9c51-2b6e8a0d4f93",
     "Name": "Musician",
     "Type": "ModelAddRule",
-    "OwnerId": "a3f9c1e7b4d0a8c6e2f5b9d7e",
+    "OwnerId": "d12c74273609ac8bf517f573e",
     "WDSDataId": "musician",
     "StatlineIndex": "1"
   },
@@ -291,7 +291,7 @@
     "Id": "f3a8b1d4-7c9e-4a62-9e15-6b2f0d8c4a91",
     "Name": "Standard Bearer",
     "Type": "ModelAddRule",
-    "OwnerId": "a3f9c1e7b4d0a8c6e2f5b9d7e",
+    "OwnerId": "d12c74273609ac8bf517f573e",
     "WDSDataId": "standard_bearer",
     "StatlineIndex": "1"
   },

--- a/WDS/Vermin Swarm/profiles.json
+++ b/WDS/Vermin Swarm/profiles.json
@@ -2225,7 +2225,7 @@
       {
         "Name": "Dreadmill Chariots",
         "Values": {
-          "Ad": "7",
+          "Ad": "D6+7",
           "Ma": "5",
           "Di": "6",
           "Hgt": "4"


### PR DESCRIPTION
**PR** #75 has been merged into preproduction and main branches 3 days ago

**WH** : all **AB**s units checked OK except below discrepancies:

**DE** / Dancers of Yema:
there is a "cosmetic" bug: all models are currently deployed with a banner
I made a script mistake by swapping 2 indexes: **DE** options.json file referred to the profileIDs instead of the unitIDs

**VS** / Dreadmill Chariots:
Cha **D6**+7 

Creating this new **PR** to implement those corrections.