### PR TITLE
AB - units profiles update - KoE - typo correction

### DIFF
--- a/WDS/Kingdom of Equitaine/profiles.json
+++ b/WDS/Kingdom of Equitaine/profiles.json
@@ -2614,8 +2614,8 @@
       {
         "Name": "Knights Penitent",
         "Values": {
-          "Ad": "7",
-          "Ma": "7",
+          "Ad": "8",
+          "Ma": "8",
           "Di": "8",
           "Hgt": "2"
         },


### PR DESCRIPTION
Another unnoticed discrepancy:

**KoE** / Knights Penitent:
Cha: 7 ↗ 8
Mob: 7 ↗8