### PR TITLE
AB - units profiles update - KoE - typo correction

### DIFF
--- a/WDS/Kingdom of Equitaine/profiles.json
+++ b/WDS/Kingdom of Equitaine/profiles.json
@@ -122,7 +122,7 @@
       {
         "Name": "Heraldic Steed",
         "Values": {
-          "At": "2",
+          "At": "1",
           "Of": "4",
           "St": "4",
           "AP": "1",
@@ -1699,7 +1699,7 @@
       {
         "Name": "Heraldic Steed",
         "Values": {
-          "At": "2",
+          "At": "1",
           "Of": "4",
           "St": "4",
           "AP": "1",


### PR DESCRIPTION
Noticed another discrepancy (but not related to V3.0.3 update):

**KoE** / Damsel + Folk Hero / Heraldic Steed: Att: 2 > 1

I've corrected errors in WDS on WH TEST server.