### PR TITLE
ABs / Height 0 units (Swarms, ..  / Add Extra Support (3) rule

### DIFF
--- a/WDS/Daemon Legions/statlines.json
+++ b/WDS/Daemon Legions/statlines.json
@@ -2242,6 +2242,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
+             {
                "Id":  "rulebook-magical_attacks"
              },
              {

--- a/WDS/Kingdom of Equitaine/statlines.json
+++ b/WDS/Kingdom of Equitaine/statlines.json
@@ -2951,6 +2951,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
+             {
                "Id":  "rulebook-magical_attacks"
              },
              {

--- a/WDS/Orcs and Goblins/statlines.json
+++ b/WDS/Orcs and Goblins/statlines.json
@@ -3388,6 +3388,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
+             {
                "Id":  "rule_tag_grotling"
              }
            ]

--- a/WDS/Saurian Ancients/statlines.json
+++ b/WDS/Saurian Ancients/statlines.json
@@ -1744,6 +1744,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
+             {
                "Id":  "rulebook-poison_attacks"
              },
              {

--- a/WDS/Undying Dynasties/statlines.json
+++ b/WDS/Undying Dynasties/statlines.json
@@ -1951,6 +1951,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
+             {
                "Id":  "rulebook-poison_attacks"
              },
              {

--- a/WDS/Vampire Covenant/statlines.json
+++ b/WDS/Vampire Covenant/statlines.json
@@ -418,6 +418,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
+             {
                "Id":  "rulebook-magical_attacks"
              },
              {
@@ -1982,6 +1986,10 @@
                "Agi":  "2"
              },
     "Children":  [
+             {
+               "Id":  "rulebook-extra_support",
+               "Info":  "(3)"
+             },
              {
                "Id":  "rule_tag_zombie"
              },

--- a/WDS/Vermin Swarm/statlines.json
+++ b/WDS/Vermin Swarm/statlines.json
@@ -1423,6 +1423,10 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-extra_support",
+               "Info": "(3)"
+             },
+             {
                "Id":  "rule_tag_beast"
              }
            ]


### PR DESCRIPTION
Update Extra Support (3) rule for 8 units across 7 **AB**s
All modifications have been tested on **WH TEST**.
**PR** to be reviewed and **MR** to be implemented into pre-production-WDSv2 branch and afterwards pushed to **WH PROD**.