### PR TITLE
AB / DL / Threshing Engine / models with Standard Bearer get incorrect base size

### DIFF
--- a/WDS/Daemon Legions/modifiedunit.json
+++ b/WDS/Daemon Legions/modifiedunit.json
@@ -86,11 +86,13 @@
     },
     {
         "OptionId":  "fce4934c-7b19-4f27-b538-d3ba50fd2f90",
-        "UnitId":  "68357f31790d8280c4b1f0b5"
+        "UnitId":  "68357f31790d8280c4b1f0b5",
+        "NewProfileId":  "68357f31790d8280c4b1f0b7_horde_thresher"
     },
     {
         "OptionId":  "987435d9-ef74-46be-a002-5b40850d1a6b",
-        "UnitId":  "68357f31790d8280c4b1f0b5"
+        "UnitId":  "68357f31790d8280c4b1f0b5",
+        "NewProfileId":  "68357f31790d8280c4b1f0b7_legion_thresher"
     },
     {
         "OptionId":  "c9519cd5-2b08-4a2e-9017-51463bfb9821",

--- a/WDS/Daemon Legions/options.json
+++ b/WDS/Daemon Legions/options.json
@@ -78,22 +78,12 @@
   {
     "Id": "fce4934c-7b19-4f27-b538-d3ba50fd2f90",
     "Name": "Horde Thresher",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "dl-horde_thresher"
-      }
-    ]
+    "Type": 3
   },
   {
     "Id": "987435d9-ef74-46be-a002-5b40850d1a6b",
     "Name": "Legion Thresher",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "dl-legion_thresher"
-      }
-    ]
+    "Type": 3
   },
   {
     "Id": "b0c4d0ba-0ced-499e-a42c-d785561851d5",

--- a/WDS/Daemon Legions/profiles.json
+++ b/WDS/Daemon Legions/profiles.json
@@ -490,7 +490,59 @@
         "Id": "statline_119"
       },
       {
-        "Id": "statline_120"
+        "Id": "statline_2120"
+      }
+    ]
+  },
+  {
+    "Id": "68357f31790d8280c4b1f0b7_horde_thresher",
+    "Name": "Threshing Engine - Horde Thresher",
+    "Type": "Profile",
+    "BaseId": "12",
+    "Children": [
+      {
+        "Id": "statline_160"
+      },
+      {
+        "Id": "statline_2161"
+      },
+      {
+        "Id": "statline_2162"
+      },
+      {
+        "Id": "statline_2119"
+      },
+      {
+        "Id": "statline_2120"
+      },
+      {
+        "Id": "dl-horde_thresher"
+      }
+    ]
+  },
+  {
+    "Id": "68357f31790d8280c4b1f0b7_legion_thresher",
+    "Name": "Threshing Engine - Legion Thresher",
+    "Type": "Profile",
+    "BaseId": "14",
+    "Children": [
+      {
+        "Id": "statline_160"
+      },
+      {
+        "Id": "statline_3161"
+      },
+      {
+        "Id": "statline_3162"
+      },
+      {
+        "Id": "statline_3119"
+      },
+      {
+        "Id": "statline_3120"
+      },
+      {
+        "Id": "dl-legion_thresher"
       }
     ]
   },

--- a/WDS/Daemon Legions/statlines.json
+++ b/WDS/Daemon Legions/statlines.json
@@ -861,6 +861,9 @@
                "Id":  "rulebook-magical_attacks"
              },
              {
+               "Id":  "rule_tag_daemon"
+             },
+             {
                "Id":  "rule_tag_mount"
              }
            ]
@@ -2053,6 +2056,195 @@
              {
                "Id":  "dl-smother",
                "Info":  "(1)"
+             },
+             {
+               "Id":  "rule_tag_daemon"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2161",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "6",
+               "Def":  "4",
+               "Res":  "4",
+               "Arm":  "0",
+               "Aeg":  "5"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-aegis",
+               "Info":  "(5+)"
+             },
+             {
+               "Id":  "rulebook-hard_target",
+               "Info":  "(1)"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2162",
+    "Name":  "Tiller (3)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "3",
+               "Off":  "4",
+               "Str":  "3",
+               "AP":  "1",
+               "Agi":  "5"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "dl-smother",
+               "Info":  "(2)"
+             },
+             {
+               "Id":  "rule_tag_daemon"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2119",
+    "Name":  "Hellsteed (3)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "1",
+               "Off":  "3",
+               "Str":  "3",
+               "AP":  "0",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "rule_tag_daemon"
+             },
+             {
+               "Id":  "rule_tag_mount"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2120",
+    "Name":  "Chassis",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  null,
+               "Off":  null,
+               "Str":  "4",
+               "AP":  "3",
+               "Agi":  null
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-impact_hits",
+               "Info":  "(3D3)"
+             },
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "rule_tag_construct"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3161",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "8",
+               "Def":  "4",
+               "Res":  "4",
+               "Arm":  "0",
+               "Aeg":  "5"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-aegis",
+               "Info":  "(5+)"
+             },
+             {
+               "Id":  "rulebook-hard_target",
+               "Info":  "(1)"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3162",
+    "Name":  "Tiller (4)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "3",
+               "Off":  "4",
+               "Str":  "3",
+               "AP":  "1",
+               "Agi":  "5"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "dl-smother",
+               "Info":  "(2)"
+             },
+             {
+               "Id":  "rule_tag_daemon"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3119",
+    "Name":  "Hellsteed (4)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "1",
+               "Off":  "3",
+               "Str":  "3",
+               "AP":  "0",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "rule_tag_daemon"
+             },
+             {
+               "Id":  "rule_tag_mount"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3120",
+    "Name":  "Chassis",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  null,
+               "Off":  null,
+               "Str":  "4",
+               "AP":  "3",
+               "Agi":  null
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-impact_hits",
+               "Info":  "(4D3)"
+             },
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "rule_tag_construct"
              }
            ]
   },

--- a/WDS/manifest.json
+++ b/WDS/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version":  50,
+    "version":  51,
     "files":  [
                   "bases.json",
                   "cards.json",


### PR DESCRIPTION
correction update of **DL**/Threshing Engine unit profiles and options
have verified all implemented modifications on **WH TEST**
**PR** to be reviewed and MR to be implemented into pre-production-**WDSv2** branch and afterwards pushed to **WH PROD**
..
<img width="1738" height="949" alt="image" src="https://github.com/user-attachments/assets/10a44800-f3b4-437d-9c14-fc087d921ff2" />
