### PR TITLE
AB / units with extended base size via option / 2nd batch

### DIFF
--- a/WDS/Beast Herds/modifiedunit.json
+++ b/WDS/Beast Herds/modifiedunit.json
@@ -218,5 +218,22 @@
     {
         "OptionId":  "359dd0e3-d486-4af8-b64b-536ad1ad6208",
         "UnitId":  "68357f27790d8280c4b1e6d5"
+    },
+    {
+        "OptionId":  "95381f19-cd72-4704-9c3b-77ebcdc8cb54",
+        "UnitId":  "68357f29790d8280c4b1e740",
+        "NewProfileId":  "68357f29790d8280c4b1e740_big_brother"
+    },
+    {
+        "OptionId":  "cff23609-26e8-4392-ae1d-fbd152b8a62c",
+        "UnitId":  "68357f29790d8280c4b1e740"
+    },
+    {
+        "OptionId":  "279ecf89-0714-42a9-8761-54d247b146da",
+        "UnitId":  "68357f29790d8280c4b1e740"
+    },
+    {
+        "OptionId":  "d9f53bcc-072d-4af9-91e2-c4451dc95eef",
+        "UnitId":  "68357f29790d8280c4b1e740"
     }
 ]

--- a/WDS/Beast Herds/options.json
+++ b/WDS/Beast Herds/options.json
@@ -61,5 +61,32 @@
         "Type": "Rule"
       }
     ]
+  },
+  {
+    "Id": "cff23609-26e8-4392-ae1d-fbd152b8a62c",
+    "Name": "Uprooted Tree",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "bh-uprooted_tree",
+        "Type": "Rule"
+      }
+    ]
+  },
+  {
+    "Id": "d9f53bcc-072d-4af9-91e2-c4451dc95eef",
+    "Name": "Beer Barrel",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "bh-beer_barrel",
+        "Type": "Rule"
+      }
+    ]
+  },
+  {
+    "Id": "95381f19-cd72-4704-9c3b-77ebcdc8cb54",
+    "Name": "Big Brother",
+    "Type": 3
   }
 ]

--- a/WDS/Beast Herds/profiles.json
+++ b/WDS/Beast Herds/profiles.json
@@ -512,6 +512,26 @@
     ]
   },
   {
+    "Id": "68357f29790d8280c4b1e740_big_brother",
+    "Name": "Beast Giant - Big Brother ",
+    "Type": "Profile",
+    "BaseId": "17",
+    "Children": [
+      {
+        "Id": "statline_81"
+      },
+      {
+        "Id": "statline_2082"
+      },
+      {
+        "Id": "statline_2083"
+      },
+      {
+        "Id": "rulebook-big_brother"
+      }
+    ]
+  },
+  {
     "Id": "68357f29790d8280c4b1e74f",
     "Name": "Totemic Beast",
     "Type": "Profile",

--- a/WDS/Beast Herds/statlines.json
+++ b/WDS/Beast Herds/statlines.json
@@ -1831,6 +1831,9 @@
              },
     "Children":  [
              {
+               "Id":  "bh-drunkard"
+             },
+             {
                "Id":  "bh-giant_see_giant_do"
              },
              {
@@ -1841,6 +1844,10 @@
              },
              {
                "Id":  "rulebook-terror"
+             },
+             {
+               "Id":  "rulebook-strider",
+               "Info":  "(Forest)"
              }
            ]
   },
@@ -1874,6 +1881,45 @@
              {
                "Id":  "rulebook-stomp_attack",
                "Info":  "(D6)"
+             },
+             {
+               "Id":  "rule_tag_giant"
+             },
+             {
+               "Id":  "rule_tag_light_armour"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2082",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "9",
+               "Def":  "3",
+               "Res":  "5",
+               "Arm":  "1",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_2083",
+    "Name":  "Beast Giant",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "5",
+               "Off":  "3",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-rage"
+             },
+             {
+               "Id":  "rulebook-stomp_attack",
+               "Info":  "(D6, Maximised)"
              },
              {
                "Id":  "rule_tag_giant"

--- a/WDS/Dread Elves/modifiedunit.json
+++ b/WDS/Dread Elves/modifiedunit.json
@@ -554,5 +554,10 @@
         "OptionId":  "1f78713a-f6d0-4f3f-8c37-6980663bb5e5",
         "UnitId":  "68357f37790d8280c4b1fb75",
         "NewProfileId": "68357f37790d8280c4b1fb75-yema"
+    },
+    {
+        "OptionId":  "8b4d5c19-6852-4291-a1a0-9ab841a568a2",
+        "UnitId":  "68357f39790d8280c4b1fc86",
+        "NewProfileId":  "68357f39790d8280c4b1fc87"
     }
 ]

--- a/WDS/Dread Elves/options.json
+++ b/WDS/Dread Elves/options.json
@@ -119,5 +119,10 @@
     "Id": "1f78713a-f6d0-4f3f-8c37-6980663bb5e5",
     "Name": "Altar of Yema",
     "Type": 3    
+  },
+  {
+    "Id": "8b4d5c19-6852-4291-a1a0-9ab841a568a2",
+    "Name": "Colossal Kraken",
+    "Type": 3
   }
 ]

--- a/WDS/Dread Elves/profiles.json
+++ b/WDS/Dread Elves/profiles.json
@@ -896,6 +896,29 @@
     ]
   },
   {
+    "Id": "68357f39790d8280c4b1fc87",
+    "Name": "Kraken - Colossal Kraken",
+    "Type": "Profile",
+    "BaseId": "14",
+    "Children": [
+      {
+        "Id": "statline_315"
+      },
+      {
+        "Id": "statline_2316"
+      },
+      {
+        "Id": "statline_2296"
+      },
+      {
+        "Id": "statline_317"
+      },
+      {
+        "Id": "de-colossal_kraken"
+      }
+    ]
+  },
+  {
     "Id": "68357f39790d8280c4b1fc88",
     "Name": "Hydra",
     "Type": "Profile",

--- a/WDS/Dread Elves/statlines.json
+++ b/WDS/Dread Elves/statlines.json
@@ -2864,6 +2864,49 @@
            ]
   },
   {
+    "Id": "statline_2316",
+    "Name": "",
+    "Type": "Statline",
+    "Attributes": {
+      "HP": "8",
+      "Def": "5",
+      "Res": "5",
+      "Arm": "3",
+      "Aeg": "-"
+    },
+    "Children": [
+      {
+        "Id": "de-coastal_predator"
+      },
+      {
+        "Id": "rulebook-distracting",
+          "Info": "(1)"
+      },
+      {
+        "Id": "rulebook-hard_target",
+          "Info": "(1)"
+      }
+    ]
+  },
+  {
+    "Id": "statline_2296",
+    "Name": "Lashmaster (4)",
+    "Type": "Statline",
+    "Attributes": {
+      "Att": "1",
+      "Off": "5",
+      "Str": "3",
+      "AP": "0",
+      "Agi": "5"
+    },
+    "Children": [
+      {
+        "Id": "rulebook-first_strike",
+        "Info": "(Artistry of Death)"
+      }
+    ]
+  },
+  {
     "Id":  "statline_318",
     "Name":  "",
     "Type":  "Statline",

--- a/WDS/Infernal Dwarves/modifiedunit.json
+++ b/WDS/Infernal Dwarves/modifiedunit.json
@@ -191,11 +191,16 @@
         "UnitId":  "68357f56790d8280c4b22628"
     },
     {
-        "OptionId":  "279ecf89-0714-42a9-8761-54d247b146da",
-        "UnitId":  "68357f5a790d8280c4b2285a"
+        "OptionId":  "5ed32382-f745-467d-97f3-03d62d3e293e",
+        "UnitId":  "68357f5a790d8280c4b2285a",
+        "NewProfileId":  "68357f5a790d8280c4b2285a_big_brother"
     },
     {
         "OptionId":  "139fa650-4057-49bc-8f07-fc2bb3eb6c0f",
+        "UnitId":  "68357f5a790d8280c4b2285a"
+    },
+    {
+        "OptionId":  "279ecf89-0714-42a9-8761-54d247b146da",
         "UnitId":  "68357f5a790d8280c4b2285a"
     },
     {

--- a/WDS/Infernal Dwarves/options.json
+++ b/WDS/Infernal Dwarves/options.json
@@ -167,5 +167,10 @@
     "Id": "1276cc20-6fa1-40b7-8a2b-b4f1d937e6ea",
     "Name": "Walking Volcano",
     "Type": 3
+  },
+  {
+    "Id": "5ed32382-f745-467d-97f3-03d62d3e293e",
+    "Name": "Big Brother",
+    "Type": 3
   }
 ]

--- a/WDS/Infernal Dwarves/profiles.json
+++ b/WDS/Infernal Dwarves/profiles.json
@@ -784,5 +784,25 @@
         "Id": "statline_726"
       }
     ]
+  },
+  {
+    "Id": "68357f5a790d8280c4b2285a_big_brother",
+    "Name": "Citizen Giant - Big Brother",
+    "Type": "Profile",
+    "BaseId": "17",
+    "Children": [
+      {
+        "Id": "statline_724"
+      },
+      {
+        "Id": "statline_2725"
+      },
+      {
+        "Id": "statline_2726"
+      },
+      {
+        "Id": "rulebook-big_brother"
+      }
+    ]
   }
 ]

--- a/WDS/Infernal Dwarves/statlines.json
+++ b/WDS/Infernal Dwarves/statlines.json
@@ -2913,6 +2913,13 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-commanding_presence",
+               "Info":  "(12\", Insignificant)"
+             },
+             {
+               "Id":  "rulebook-first_strike",
+               "Info":  "(Stubborn)"
+             },{
                "Id":  "id-giant_see_giant_do"
              },
              {
@@ -2936,7 +2943,12 @@
                "Res":  "5",
                "Arm":  "3",
                "Aeg":  "-"
+             },
+    "Children":  [
+             {
+               "Id":  "id-infernal_armour"
              }
+           ]
   },
   {
     "Id":  "statline_726",
@@ -2956,6 +2968,53 @@
              {
                "Id":  "rulebook-stomp_attack",
                "Info":  "(D6)"
+             },
+             {
+               "Id":  "rule_tag_dwarf"
+             },
+             {
+               "Id":  "rule_tag_giant"
+             },
+             {
+               "Id":  "rule_tag_metal_armour"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2725",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "9",
+               "Def":  "3",
+               "Res":  "5",
+               "Arm":  "3",
+               "Aeg":  "-"
+             },
+    "Children":  [
+             {
+               "Id":  "id-infernal_armour"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_2726",
+    "Name":  "Citizen Giant",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "5",
+               "Off":  "3",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-rage"
+             },
+             {
+               "Id":  "rulebook-stomp_attack",
+               "Info":  "(D6, Maximised)"
              },
              {
                "Id":  "rule_tag_dwarf"

--- a/WDS/Ogre Khans/modifiedunit.json
+++ b/WDS/Ogre Khans/modifiedunit.json
@@ -163,6 +163,11 @@
         "UnitId":  "68357f6a790d8280c4b2419b"
     },
     {
+        "OptionId":  "a20f8de8-dd3a-45fc-a672-dc74f407cd01",
+        "UnitId":  "68357f6e790d8280c4b244e6",
+        "NewProfileId": "68357f6e790d8280c4b244e6-big_brother"
+    },
+    {
         "OptionId":  "39ff8caf-d9ce-45ee-8cef-bcf2e964c669",
         "UnitId":  "68357f6e790d8280c4b244e6"
     },
@@ -172,6 +177,18 @@
     },
     {
         "OptionId":  "5fac2b67-1fc1-4c51-9dec-5e620009bba6",
+        "UnitId":  "68357f6e790d8280c4b244e6"
+    },
+    {
+        "OptionId":  "ee914d44-b3cc-4d7d-9909-3b992c4b4212",
+        "UnitId":  "68357f6e790d8280c4b244e6"
+    },
+    {
+        "OptionId":  "865cbc87-d9c8-4b59-9b46-fc503e63de37",
+        "UnitId":  "68357f6e790d8280c4b244e6"
+    },
+    {
+        "OptionId":  "910d3710-8f71-476f-8a97-91c4e3b7dedf",
         "UnitId":  "68357f6e790d8280c4b244e6"
     },
     {

--- a/WDS/Ogre Khans/options.json
+++ b/WDS/Ogre Khans/options.json
@@ -169,5 +169,42 @@
         "Id":  "rulebook-vanguard"
       }
     ]
+  },
+  {
+    "Id": "a20f8de8-dd3a-45fc-a672-dc74f407cd01",
+    "Name": "Big Brother",
+    "Type": 3
+  },
+  {
+    "Id": "ee914d44-b3cc-4d7d-9909-3b992c4b4212",
+    "Name": "First Strike",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id":  "rulebook-first_strike",
+        "Info":  "(Fury)"
+      }
+    ]
+  },
+  {
+    "Id": "865cbc87-d9c8-4b59-9b46-fc503e63de37",
+    "Name": "Lethal Strike",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id":  "rulebook-lethal_strike"
+      }
+    ]
+  },
+  {
+    "Id": "910d3710-8f71-476f-8a97-91c4e3b7dedf",
+    "Name": "Devastating Charge",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id":  "rulebook-devastating_charge",
+        "Info":  "(+1 Str, +1 AP)"
+      }
+    ]
   }
 ]

--- a/WDS/Ogre Khans/profiles.json
+++ b/WDS/Ogre Khans/profiles.json
@@ -459,5 +459,22 @@
         "Id": "statline_932"
       }
     ]
+  },
+  {
+    "Id": "68357f6e790d8280c4b244e6-big_brother",
+    "Name": "Mercenary Giant - Big Brother",
+    "Type": "Profile",
+    "BaseId": "17",
+    "Children": [
+      {
+        "Id": "statline_930"
+      },
+      {
+        "Id": "statline_2931"
+      },
+      {
+        "Id": "statline_2932"
+      }
+    ]
   }
 ]

--- a/WDS/Ogre Khans/statlines.json
+++ b/WDS/Ogre Khans/statlines.json
@@ -1751,5 +1751,48 @@
                "Id":  "rule_tag_light_armour"
              }
            ]
+  },
+  {
+    "Id":  "statline_2931",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "9",
+               "Def":  "3",
+               "Res":  "5",
+               "Arm":  "1",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_2932",
+    "Name":  "Mercenary Giant",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "5",
+               "Off":  "3",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-impact_hits",
+               "Info":  "(D3)"
+             },
+             {
+               "Id":  "rulebook-rage"
+             },
+             {
+               "Id":  "rulebook-stomp_attack",
+               "Info":  "(D6, Maximised)"
+             },
+             {
+               "Id":  "rule_tag_giant"
+             },
+             {
+               "Id":  "rule_tag_light_armour"
+             }
+           ]
   }
 ]

--- a/WDS/Orcs and Goblins/modifiedunit.json
+++ b/WDS/Orcs and Goblins/modifiedunit.json
@@ -270,19 +270,20 @@
         "UnitId":  "68357f72790d8280c4b24e0c"
     },
     {
-        "OptionId":  "ac6cd92a-5b13-4ab4-8537-4d6bfb922966",
-        "UnitId":  "68357f74790d8280c4b24f7d"
+        "OptionId":  "09cf03c4-28ba-4e94-8f64-683247ef75d4",
+        "UnitId":  "68357f74790d8280c4b24f7d",
+        "NewProfileId":  "68357f74790d8280c4b24f7d_big_brother"
     },
     {
-        "OptionId":  "8ef11556-a01a-45d2-9d0d-0f8e88aada68",
+        "OptionId":  "ac6cd92a-5b13-4ab4-8537-4d6bfb922966",
         "UnitId":  "68357f74790d8280c4b24f7d"
-    },
+    },    
     {
         "OptionId":  "279ecf89-0714-42a9-8761-54d247b146da",
         "UnitId":  "68357f74790d8280c4b24f7d"
     },
     {
-        "OptionId":  "701febc5-c852-4064-90fc-7c386d2af081",
+        "OptionId":  "8ef11556-a01a-45d2-9d0d-0f8e88aada68",
         "UnitId":  "68357f74790d8280c4b24f7d"
     },
     {

--- a/WDS/Orcs and Goblins/options.json
+++ b/WDS/Orcs and Goblins/options.json
@@ -147,6 +147,21 @@
     ]
   },
   {
+    "Id": "09cf03c4-28ba-4e94-8f64-683247ef75d4",
+    "Name": "Big Brother",
+    "Type": 3
+  },
+  {
+    "Id": "8ef11556-a01a-45d2-9d0d-0f8e88aada68",
+    "Name": "Beloved Mascot",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "ong-beloved_mascot"
+      }
+    ]
+  },
+  {
     "Id": "ac6cd92a-5b13-4ab4-8537-4d6bfb922966",
     "Name": "Armed to the Teeth",
     "Type": 1,
@@ -155,11 +170,6 @@
         "Id": "ong-armed_to_the_teeth"
       }
     ]
-  },
-  {
-    "Id": "8ef11556-a01a-45d2-9d0d-0f8e88aada68",
-    "Name": "Beloved Mascots",
-    "Type": 1
   },
   {
     "Id": "712fc769-17c7-49de-aa47-bce44e31ac0b",
@@ -350,11 +360,6 @@
   {
     "Id": "42660827-4ea4-4491-8701-750aa2c2e0da",
     "Name": "Mauler - Creepy",
-    "Type": 1
-  },
-  {
-    "Id": "701febc5-c852-4064-90fc-7c386d2af081",
-    "Name": "Nets",
     "Type": 1
   },
   {

--- a/WDS/Orcs and Goblins/profiles.json
+++ b/WDS/Orcs and Goblins/profiles.json
@@ -1264,6 +1264,26 @@
     ]
   },
   {
+    "Id": "68357f74790d8280c4b24f7d_big_brother",
+    "Name": "Giant - Big Brother ",
+    "Type": "Profile",
+    "BaseId": "17",
+    "Children": [
+      {
+        "Id": "statline_1086"
+      },
+      {
+        "Id": "statline_3087"
+      },
+      {
+        "Id": "statline_3088"
+      },
+      {
+        "Id": "rulebook-big_brother"
+      }
+    ]
+  },
+  {
     "Id": "68357f75790d8280c4b24fc5",
     "Name": "Great Green Idol",
     "Type": "Profile",

--- a/WDS/Orcs and Goblins/statlines.json
+++ b/WDS/Orcs and Goblins/statlines.json
@@ -3959,6 +3959,9 @@
              },
              {
                "Id":  "rulebook-terror"
+             },
+             {
+               "Id":  "rulebook-unruly"
              }
            ]
   },
@@ -3987,11 +3990,56 @@
              },
     "Children":  [
              {
+               "Id":  "ong-brood_rivalry"
+             },
+             {
                "Id":  "rulebook-rage"
              },
              {
                "Id":  "rulebook-stomp_attack",
                "Info":  "(D6)"
+             },
+             {
+               "Id":  "rule_tag_giant"
+             },
+             {
+               "Id":  "rule_tag_orc"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3087",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "9",
+               "Def":  "3",
+               "Res":  "5",
+               "Arm":  "1",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_3088",
+    "Name":  "Giant",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "5",
+               "Off":  "3",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "ong-brood_rivalry"
+             },
+             {
+               "Id":  "rulebook-rage"
+             },
+             {
+               "Id":  "rulebook-stomp_attack",
+               "Info":  "(D6, Maximised)"
              },
              {
                "Id":  "rule_tag_giant"

--- a/WDS/Vampire Covenant/modifiedunit.json
+++ b/WDS/Vampire Covenant/modifiedunit.json
@@ -488,6 +488,11 @@
         "UnitId":  "68357f8d790d8280c4b26e16_skeletal_steed"
     },
     {
+        "OptionId":  "6226316e-2ed9-4af6-b7d5-51a34b236990",
+        "UnitId":  "68357f91790d8280c4b26fd9",
+        "NewProfileId":  "68357f91790d8280c4b26fd9_extended_chassis"
+    },
+    {
         "OptionId": "ed9f349a-b950-443e-9824-95512abbbd90",
         "UnitId": "68357f91790d8280c4b26ff0"
     }

--- a/WDS/Vampire Covenant/options.json
+++ b/WDS/Vampire Covenant/options.json
@@ -39,6 +39,11 @@
         "Name":  "Cadaver Wagon",
         "Type":  0
     },
+  {
+        "Id":  "6226316e-2ed9-4af6-b7d5-51a34b236990",
+        "Name":  "Extended Chassis",
+        "Type":  3
+    },
     {
         "Id": "ed9f349a-b950-443e-9824-95512abbbd90",
         "Name": "Wizard Conclave",

--- a/WDS/Vampire Covenant/profiles.json
+++ b/WDS/Vampire Covenant/profiles.json
@@ -651,7 +651,33 @@
         "Id": "statline_1409"
       },
       {
-        "Id": "statline_7"
+        "Id": "statline_3410"
+      }
+    ]
+  },
+  {
+    "Id": "68357f91790d8280c4b26fd9_extended_chassis",
+    "Name": "Dark Coach - Extended Chassis",
+    "Type": "Profile",
+    "BaseId": "22",
+    "Children": [
+      {
+        "Id": "statline_1485"
+      },
+      {
+        "Id": "statline_1486"
+      },
+      {
+        "Id": "statline_1487"
+      },
+      {
+        "Id": "statline_3409"
+      },
+      {
+        "Id": "statline_3410"
+      },
+      {
+        "Id": "vc-extended_chassis"
       }
     ]
   },

--- a/WDS/Vampire Covenant/statlines.json
+++ b/WDS/Vampire Covenant/statlines.json
@@ -418,6 +418,50 @@
            ]
   },
   {
+    "Id":  "statline_3409",
+    "Name":  "Phantom Host (2)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "6",
+               "Off":  "2",
+               "Str":  "2",
+               "AP":  "1",
+               "Agi":  "2"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-magical_attacks"
+             },
+             {
+               "Id":  "rule_tag_mount"
+             },
+             {
+               "Id":  "rule_tag_spirit"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3410",
+    "Name":  "Chassis",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  null,
+               "Off":  null,
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  null
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-impact_hits",
+               "Info":  "(D6+1)"
+             },
+             {
+               "Id":  "rule_tag_construct"
+             }
+           ]
+  },
+  {
     "Id":  "statline_1410",
     "Name":  "",
     "Type":  "Statline",

--- a/WDS/Warriors of the Dark Gods/modifiedunit.json
+++ b/WDS/Warriors of the Dark Gods/modifiedunit.json
@@ -737,7 +737,20 @@
         "UnitId":  "68357f9d790d8280c4b27ce2_wasteland_behemoth"
     },
     {
+        "OptionId":  "6cdf0b73-15bf-4709-b84c-9a20a4c872bf",
+        "UnitId":  "68357fa2790d8280c4b28279",
+        "NewProfileId":  "68357fa2790d8280c4b28279_big_brother"
+    },
+    {
+        "OptionId":  "279ecf89-0714-42a9-8761-54d247b146da",
+        "UnitId":  "68357fa2790d8280c4b28279"
+    },
+    {
         "OptionId": "416ac8dd-38b8-4d25-9763-c1b88004ecf9",
+        "UnitId": "68357fa2790d8280c4b28279"
+    },
+    {
+        "OptionId": "23ba1a9d-9931-47b0-baa1-1d162288e67e",
         "UnitId": "68357fa2790d8280c4b28279"
     }
 ]

--- a/WDS/Warriors of the Dark Gods/options.json
+++ b/WDS/Warriors of the Dark Gods/options.json
@@ -90,10 +90,19 @@
     ]
   },
   {
+    "Id": "6cdf0b73-15bf-4709-b84c-9a20a4c872bf",
+    "Name": "Big Brother",
+    "Type": 3
+  },
+  {
     "Id": "416ac8dd-38b8-4d25-9763-c1b88004ecf9",
     "Name": "Monstrous Familiar",
     "Type": 7,
     "ExtraItems": [
+      {
+        "Id": "wdg-monstrous_familiar",
+        "Type": "Rule"
+      },
       {
         "Id": "rulebook-wizard_conclave",
         "Type": "Rule"
@@ -109,6 +118,16 @@
       {
         "Id": "corruption of tin/alchemy",
         "Type": "Card"
+      }
+    ]
+  },
+  {
+    "Id": "23ba1a9d-9931-47b0-baa1-1d162288e67e",
+    "Name": "Tribal Warspear",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "wdg-tribal_warspear"
       }
     ]
   },

--- a/WDS/Warriors of the Dark Gods/profiles.json
+++ b/WDS/Warriors of the Dark Gods/profiles.json
@@ -921,6 +921,26 @@
     ]
   },
   {
+    "Id": "68357fa2790d8280c4b28279_big_brother",
+    "Name": "Marauding Giant - Big Brother ",
+    "Type": "Profile",
+    "BaseId": "17",
+    "Children": [
+      {
+        "Id": "statline_1755"
+      },
+      {
+        "Id": "statline_3756"
+      },
+      {
+        "Id": "statline_3757"
+      },
+      {
+        "Id": "rulebook-big_brother"
+      }
+    ]
+  },
+  {
     "Id": "68357fa2790d8280c4b28274",
     "Name": "Feldrak Elder",
     "Type": "Profile",

--- a/WDS/Warriors of the Dark Gods/statlines.json
+++ b/WDS/Warriors of the Dark Gods/statlines.json
@@ -2952,6 +2952,9 @@
              },
     "Children":  [
              {
+               "Id":  "rulebook-courageous"
+             },
+             {
                "Id":  "wdg-giant_see_giant_do"
              },
              {
@@ -2995,6 +2998,45 @@
              {
                "Id":  "rulebook-stomp_attack",
                "Info":  "(D6)"
+             },
+             {
+               "Id":  "rule_tag_giant"
+             },
+             {
+               "Id":  "rule_tag_light_armour"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3756",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "9",
+               "Def":  "3",
+               "Res":  "5",
+               "Arm":  "1",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_3757",
+    "Name":  "Marauding Giant",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "5",
+               "Off":  "3",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-rage"
+             },
+             {
+               "Id":  "rulebook-stomp_attack",
+               "Info":  "(D6, Maximised)"
              },
              {
                "Id":  "rule_tag_giant"

--- a/WDS/bases.json
+++ b/WDS/bases.json
@@ -124,5 +124,11 @@
     "Shape": 0,
     "Width": 80,
     "Length": 80
+  },
+  {
+    "Id": "22",
+    "Shape": 0,
+    "Width": 50,
+    "Length": 150
   }
 ]

--- a/WDS/options.json
+++ b/WDS/options.json
@@ -60,7 +60,7 @@
     "Type": 1,
     "ItemsToAdd": [
       {
-        "Id": "er-giant_club"
+        "Id": "rulebook-giant_club"
       }
     ]
   },

--- a/WDS/rules.json
+++ b/WDS/rules.json
@@ -216,6 +216,18 @@
     "Description": "While a Character is joined to a unit containing Bodyguard and the Character fulfills at least one of the requirements defined by ‘X’, that Character benefits from <u><link=\"rulebook-stubborn\">Stubborn</link></u>.\nIn addition, if the unit it is joined to has at least one <u><link=\"rulebook-proper_ranks\">Proper Rank</link></u>, the unit is considered to be <u><link=\"rulebook-steadfast\">Steadfast</link></u> for the purposes of Break Tests.\nNote: units entirely with <u><link=\"rulebook-unstable\">Unstable</link></u> do not take Break Tests."
   },
   {
+    "Id": "rulebook-big_brother",
+    "Name": "Big Brother",
+    "Type": "Rule",
+    "Description": "The model's HP are <b>set</b> to 9, its base size is changed to 75×100 mm, and its rolls for the number of hits for <u><link=\"rulebook-stomp_attack\">Stomp Attacks</link></u> is <b>Maximised</b>."
+  },
+  {
+    "Id": "rulebook-giant_club",
+    "Name": "Giant Club",
+    "Type": "Rule",
+    "Description": "Characteristics Modifiers: +1 Str, +1AP."
+  },
+  {
     "Id": "rulebook-halberd",
     "Name": "Halberd",
     "Type": "Rule",
@@ -2688,12 +2700,6 @@
     "Description": "The model gains <u><link=\"rulebook-courageous\">Courageous</link></u>."
   },
   {
-    "Id": "wdg-giant_club",
-    "Name": "Giant Club (WDG)",
-    "Type": "Rule",
-    "Description": "+1 Str and +1 AP."
-  },
-  {
     "Id": "wdg-gateway",
     "Name": "Gateway",
     "Type": "Rule",
@@ -2838,22 +2844,10 @@
     "Description": "While the bearer’s unit is part of a Combined Charge, that unit, as well as all other units that are Charging the same target, must reroll failed Charge Range rolls, and gain <u><link=\"rulebook-devastating_charge\">Devastating Charge</link></u>(<u><link=\"rulebook-hard_target\">Hard Target (1)</link></u>)."
   },
   {
-    "Id": "ong-big_brother",
-    "Name": "Big Brother (OnG)",
-    "Type": "Rule",
-    "Description": "The model's HP are <b>set</b> to 9, its base size is changed to 75×100 mm, and its rolls for the number of hits for <u><link=\"rulebook-stomp_attack\">Stomp Attack</link></u> is <b>Maximised</b>"
-  },
-  {
     "Id": "ong-beloved_mascot",
     "Name": "Beloved Mascot",
     "Type": "Rule",
-    "Description": "<u><link=\"rulebook-afflict\">Afflict (-2 Def)</link></u>."
-  },
-  {
-    "Id": "ong-giant_club",
-    "Name": "Giant Club (OnG)",
-    "Type": "Rule",
-    "Description": "+1 Str, +1 AP."
+    "Description": "<u><link=\"rulebook-afflict\">Afflict (-3 Def)</link></u>."
   },
   {
     "Id": "ong-armed_to_the_teeth",
@@ -3106,18 +3100,6 @@
     "Name": "Troll’s Bellow",
     "Type": "Rule",
     "Description": "When you activate the <u><link=\"ong-war_cry\">War Cry!</link></u>, all friendly model parts with <i>Troll</i> gain <u><link=\"rulebook-fury\">Fury</link></u>. Duration: One Turn."
-  },
-  {
-    "Id": "id-big_brother",
-    "Name": "Big Brother (ID)",
-    "Type": "Rule",
-    "Description": "The model's HP are <b>set</b> to 9, its base size is changed to 75×100 mm, and the roll for the number of hits it does with its <u><link=\"rulebook-stomp_attack\">Stomp Attack</link></u> is <b>Maximised</b>."
-  },
-  {
-    "Id": "id-giant_club",
-    "Name": "Giant Club (ID)",
-    "Type": "Rule",
-    "Description": "+1 Str, +1 AP."
   },
   {
     "Id": "id-tower_shield",
@@ -3660,18 +3642,6 @@
     "Description": "Each Character or model with <i>Dragon</i> that either:\n\n• Breaks from a <u><link=\"rulebook-round_of_combat\">Round of Combat</link></u> in which a unit containing Tergon Khan was Engaged, or\n• Selects <u><link=\"rulebook-flee_move\">Flee!</link></u> as a <u><link=\"rulebook-charge_reactions\"></link>Charge Reaction</u> when a unit containing Tergon Khan declared a Charge,\n\nSuffers D3 hits with Str 6, AP 3, <u><link=\"rulebook-magical_attacks\">Magical Attacks</link></u> and <u><link=\"rulebook-zeal\">Zeal</link></u> (<b>against</b> <i>Dragon</i>)."
   },
   {
-    "Id": "bh-big_brother",
-    "Name": "Big Brother (BH)",
-    "Type": "Rule",
-    "Description": "The model's HP are <b>set</b> to 9, and its base size is changed to 75×100 mm, and the roll for the number of hits it does with its <u><link=\"rulebook-stomp_attack\">Stomp Attack</link></u> gains <b>Maximised</b>."
-  },
-  {
-    "Id": "bh-giant_club",
-    "Name": "Giant Club (BH)",
-    "Type": "Rule",
-    "Description": "+1 Str, +1 AP."
-  },
-  {
     "Id": "bh-beast_axe",
     "Name": "Beast Axe",
     "Type": "Rule",
@@ -3681,7 +3651,7 @@
     "Id": "bh-beer_barrel",
     "Name": "Beer Barrel",
     "Type": "Rule",
-    "Description": "The model gains <u><link=\"bh-looted_booze\">Looted Booze</link></u>. One use only.\nThis weapon can be used as a Shooting Weapon with the following profile:\nAim 2+, Range 8\", Shots 1, Str 4, AP 0, <u><link=\"rulebook-accurate\">Accurate</link></u>, <u><link=\"rulebook-area_attack\">Area Attack (3×3)</link></u>, <u><link=\"rulebook-march_and_shoot\">March and Shoot</link></u>, <u><link=\"rulebook-quick_to_fire\">Quick to Fire</link></u>\nAfter this weapon has been used as a Shooting Weapon, the model loses <u><link=\"bh-looted_booze\">Looted Booze</link></u>."
+    "Description": "The model gains <u><link=\"bh-looted_booze\">Looted Booze</link></u>. One use only.\nThis weapon can be used as a Shooting Weapon with the following profile:\n\nAim 2+, Range 8\", Shots 1, Str 4, AP 0, <u><link=\"rulebook-accurate\">Accurate</link></u>, <u><link=\"rulebook-area_attack\">Area Attack (3×3)</link></u>, <u><link=\"rulebook-march_and_shoot\">March and Shoot</link></u>, <u><link=\"rulebook-quick_to_fire\">Quick to Fire</link></u>"
   },
   {
     "Id": "bh-sober",
@@ -4504,18 +4474,6 @@
     "Name": "Leader of the Pack",
     "Type": "Rule",
     "Description": "The Mammoth Hunter's base size is changed to 50×50 mm.\nThe model replaces <u><link=\"rulebook-exclusive\">Exclusive (Yetis)</link></u> with <u><link=\"rulebook-exclusive\">Exclusive (Sabretooth Tigers)</link></u>.\nWhile joined to a unit of Sabretooth Tigers, the unit gains <u><link=\"rulebook-vanguard\">Vanguard</link></u>, loses <u><link=\"rulebook-unruly\">Unruly</link></u>, and the Mammoth Hunter counts as being  of the same Height as the unit for the purposes of allocating Ranged Attacks."
-  },
-  {
-    "Id": "ok-big_brother",
-    "Name": "Big Brother (OK)",
-    "Type": "Rule",
-    "Description": "The model's HP are <b>set</b> to 9, its base size is changed to 75×100 mm, and the roll for the number of hits it does with its <u><link=\"rulebook-stomp_attack\">Stomp Attack</link></u> is <b>Maximised</b>."
-  },
-  {
-    "Id": "ok-giant_club",
-    "Name": "Giant Club (OK)",
-    "Type": "Rule",
-    "Description": "+1 Str, +1 AP."
   },
   {
     "Id": "ok-iron_fist",
@@ -6382,12 +6340,6 @@
     "Name": "Damnation",
     "Type": "Rule",
     "Description": "The unit gains <u><link=\"rulebook-solitary\">Solitary</link></u>.\nIf it fails a Break Test, replace each model of the unit with a Wretched One model:\n• The unit and its models are considered removed as a casualties.\n• Each Wretched One model is placed in the same position and facing the same direction as the model it replaces (even if the replaced model was in contact with an enemy unit: in this case, the Wretched One model is placed in contact with the enemy unit, too).\n• The Wretched One models form a new unit.\n• The Wretched One unit follows the rules for <u><link=\"rulebook-summoned_units\">Summoned Units</link></u>, except that it ignores the Unit Spacing rule when placed on the Battlefield, but can still not overlap other units or <u><link=\"rulebook-impassable_terrain\">Impassable Terrain</link></u>.\n• The Wretched One unit cannot perform any <u><link=\"rulebook-combat_reforms\">Combat Reforms</link></u> in the Round of Combat during which it is <u><link=\"rulebook-summoned_units\">Summoned</link></u>. Enemy units can do so as normal.\n• Note that the following Round of Combat is not considered the First Round of Combat for the Wretched One unit, nor for the enemy units it is Engaged with."
-  },
-  {
-    "Id": "wdg-big_brother",
-    "Name": "Big Brother (WDG)",
-    "Type": "Rule",
-    "Description": "The model's HP are <b>set</b> to 9, its base size is changed to 75×100 mm, and its rolls for the number of hits for <u><link=\"rulebook-stomp_attack\">Stomp Attacks</link></u> is <b>Maximised</b>."
   },
   {
     "Id": "wdg-monstrous_familiar",


### PR DESCRIPTION
2nd batch  update: **5** Giants + **DE**/ Kraken + **VC**/Dark Coach

🚀01/ BH / Beast Giant / Big Brother
🚀03/ DE / Kraken / Colossal Kraken
🚀07/ ID / Citizen Giant / Big Brother
🚀09/ OK / Mercenary Giant / Big Brother
🚀10/ OnG / Giant / Big Brother
🚀14/ VC / Dark Coach / Extended Chassis
🚀16/ WDG / Marauding Giant / Big Brother

have verified all implemented modifications on **WH TEST**:
..
<img width="1004" height="502" alt="image" src="https://github.com/user-attachments/assets/43009132-ab7a-4ba8-9a3b-53d6032ab206" />
..
**PR** to be reviewed and **MR** to be implemented into pre-production-**WDSv2** branch and afterwards pushed to **WH PROD**