### PR TITLE
AB / units with extended base size via option / 3rd batch

### DIFF
--- a/WDS/Dread Elves/modifiedunit.json
+++ b/WDS/Dread Elves/modifiedunit.json
@@ -25,6 +25,16 @@
         "NewUnitId":  "68357f34790d8280c4b1f29f_manticore"
     },
     {
+        "OptionId":  "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+        "UnitId":  "68357f34790d8280c4b1f29f",
+        "NewProfileId":  "68357f34790d8280c4b1f29f_extraordinary_specimen_manticore"
+    },
+    {
+        "OptionId":  "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+        "UnitId":  "68357f34790d8280c4b1f29f_manticore",
+        "NewProfileId":  "68357f34790d8280c4b1f29f_extraordinary_specimen_manticore"
+    },
+    {
         "OptionId":  "d3983233-b1fd-42d5-a43a-2af47dc81f96",
         "UnitId":  "68357f34790d8280c4b1f29f",
         "NewUnitId":  "68357f34790d8280c4b1f29f_imperious_dragon"
@@ -53,6 +63,16 @@
         "OptionId":  "0aba87c2-0773-47c7-ba5e-2637c502d9d6",
         "UnitId":  "68357f35790d8280c4b1f585",
         "NewUnitId":  "68357f35790d8280c4b1f585_manticore"
+    },    
+    {
+        "OptionId":  "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+        "UnitId":  "68357f35790d8280c4b1f585",
+        "NewProfileId":  "68357f35790d8280c4b1f585_extraordinary_specimen_manticore"
+    },
+    {
+        "OptionId":  "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+        "UnitId":  "68357f35790d8280c4b1f585_manticore",
+        "NewProfileId":  "68357f35790d8280c4b1f585_extraordinary_specimen_manticore"
     },
     {
         "OptionId":  "8c3953a8-f297-4ea5-aebf-5983fff4f53a",
@@ -78,6 +98,16 @@
         "OptionId":  "d3983233-b1fd-42d5-a43a-2af47dc81f96",
         "UnitId":  "68357f35790d8280c4b1f8ba",
         "NewUnitId":  "68357f35790d8280c4b1f8ba_imperious_dragon"
+    },
+    {
+        "OptionId":  "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+        "UnitId":  "68357f35790d8280c4b1f8ba",
+        "NewProfileId":  "68357f35790d8280c4b1f8ba_extraordinary_specimen_manticore"
+    },
+    {
+        "OptionId":  "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+        "UnitId":  "68357f35790d8280c4b1f8ba_manticore",
+        "NewProfileId":  "68357f35790d8280c4b1f8ba_extraordinary_specimen_manticore"
     },
     {
         "OptionId":  "3a074005-878f-422e-a475-42dd13ce86ce",

--- a/WDS/Dread Elves/options.json
+++ b/WDS/Dread Elves/options.json
@@ -20,6 +20,11 @@
     "Type": 0
   },
   {
+    "Id": "6460d9cf-d5bc-4e8e-8293-2f28eb0f9fae",
+    "Name": "Extraordinary Specimen",
+    "Type": 3
+  },
+  {
     "Id": "d3983233-b1fd-42d5-a43a-2af47dc81f96",
     "Name": "Imperious Dragon",
     "Type": 0

--- a/WDS/Dread Elves/profiles.json
+++ b/WDS/Dread Elves/profiles.json
@@ -120,6 +120,29 @@
     ]
   },
   {
+    "Id": "68357f34790d8280c4b1f29f_extraordinary_specimen_manticore",
+    "Name": "Dread Prince on Extraordinary Specimen Manticore",
+    "Type": "Profile",
+    "BaseId": "2",
+    "Children": [
+      {
+        "Id": "statline_213"
+      },
+      {
+        "Id": "statline_214"
+      },
+      {
+        "Id": "statline_200"
+      },
+      {
+        "Id": "statline_2215"
+      },
+      {
+        "Id": "de-extraordinary_specimen"
+      }
+    ]
+  },
+  {
     "Id": "7e30d4e8-80b0-4cc7-a3b3-90d12f7feffd",
     "Name": "Dread Prince on Imperious Dragon",
     "Type": "Profile",
@@ -260,6 +283,29 @@
     ]
   },
   {
+    "Id": "68357f35790d8280c4b1f585_extraordinary_specimen_manticore",
+    "Name": "Silexian Officer on Extraordinary Specimen Manticore",
+    "Type": "Profile",
+    "BaseId": "2",
+    "Children": [
+      {
+        "Id": "statline_230"
+      },
+      {
+        "Id": "statline_231"
+      },
+      {
+        "Id": "statline_221"
+      },
+      {
+        "Id": "statline_2215"
+      },
+      {
+        "Id": "de-extraordinary_specimen"
+      }
+    ]
+  },
+  {
     "Id": "68357f35790d8280c4b1f858",
     "Name": "Temple Exarch",
     "Type": "Profile",
@@ -370,6 +416,29 @@
       },
       {
         "Id": "statline_215"
+      }
+    ]
+  },
+  {
+    "Id": "68357f35790d8280c4b1f8ba_extraordinary_specimen_manticore",
+    "Name": "Sanctioned Warlock on Extraordinary Specimen Manticore",
+    "Type": "Profile",
+    "BaseId": "2",
+    "Children": [
+      {
+        "Id": "statline_244"
+      },
+      {
+        "Id": "statline_245"
+      },
+      {
+        "Id": "statline_237"
+      },
+      {
+        "Id": "statline_2215"
+      },
+      {
+        "Id": "de-extraordinary_specimen"
       }
     ]
   },

--- a/WDS/Dread Elves/statlines.json
+++ b/WDS/Dread Elves/statlines.json
@@ -375,6 +375,30 @@
            ]
   },
   {
+    "Id": "statline_2215",
+    "Name": "Manticore",
+    "Type": "Statline",
+    "Attributes": {
+      "Att": "4",
+      "Off": "5",
+      "Str": "5",
+      "AP": "2",
+      "Agi": "5"
+    },
+    "Children": [
+      {
+        "Id": "rulebook-lethal_strike"
+      },
+      {
+        "Id": "rulebook-stomp_attack",
+        "Info": "(D3)"
+      },
+      {
+        "Id": "rule_tag_beast"
+      }
+    ]
+  },
+  {
     "Id":  "statline_216",
     "Name":  "",
     "Type":  "Statline",

--- a/WDS/Ogre Khans/profiles.json
+++ b/WDS/Ogre Khans/profiles.json
@@ -474,6 +474,9 @@
       },
       {
         "Id": "statline_2932"
+      },
+      {
+        "Id": "rulebook-big_brother"
       }
     ]
   }

--- a/WDS/Orcs and Goblins/modifiedunit.json
+++ b/WDS/Orcs and Goblins/modifiedunit.json
@@ -404,18 +404,19 @@
     },
     {
         "OptionId":  "6d8b4a47-81bd-4a53-a34d-91a6e0d109ba",
-        "UnitId":  "68357f76790d8280c4b24fcc"
-    },
-        {
-        "OptionId":  "6d8b4a47-81bd-4a53-a34d-91a6e0d109ba",
-        "UnitId":  "68357f76790d8280c4b24fcc"
-    },	
-    {
-        "OptionId":  "2c349561-5692-46fb-8477-64b88e03f508",
-        "UnitId":  "68357f76790d8280c4b24fcc"
+        "UnitId":  "68357f76790d8280c4b24fcc",
+        "NewProfileId":  "68357f76790d8280c4b24fcc_immense_bulk"
     },
     {
         "OptionId":  "1762cb82-ee5c-4b1c-bf7a-5af337ef2127",
+        "UnitId":  "68357f76790d8280c4b24fcc"
+    },    
+    {
+        "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
+        "UnitId":  "68357f76790d8280c4b24fcc"
+    },
+    {
+        "OptionId":  "2c349561-5692-46fb-8477-64b88e03f508",
         "UnitId":  "68357f76790d8280c4b24fcc"
     },
     {

--- a/WDS/Orcs and Goblins/options.json
+++ b/WDS/Orcs and Goblins/options.json
@@ -262,12 +262,7 @@
   {
     "Id": "6d8b4a47-81bd-4a53-a34d-91a6e0d109ba",
     "Name": "Immense Bulk",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "ong-immense_bulk"
-      }
-    ]
+    "Type": 3
   },
   {
     "Id": "2c349561-5692-46fb-8477-64b88e03f508",

--- a/WDS/Orcs and Goblins/profiles.json
+++ b/WDS/Orcs and Goblins/profiles.json
@@ -1319,5 +1319,28 @@
         "Id": "statline_1095"
       }
     ]
-  }
+  },
+  {
+    "Id": "68357f76790d8280c4b24fcc_immense_bulk",
+    "Name": "Guardian Behemoth - Immense Bulk",
+    "Type": "Profile",
+    "BaseId": "14",
+    "Children": [
+      {
+        "Id": "statline_1092"
+      },
+      {
+        "Id": "statline_3093"
+      },
+      {
+        "Id": "statline_3094"
+      },
+      {
+        "Id": "statline_1095"
+      },
+      {
+        "Id": "ong-immense_bulk"
+      }
+    ]
+  } 
 ]

--- a/WDS/Orcs and Goblins/statlines.json
+++ b/WDS/Orcs and Goblins/statlines.json
@@ -4221,5 +4221,41 @@
                "Id":  "rule_tag_mount"
              }
            ]
+  },
+  {
+    "Id":  "statline_3093",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "8",
+               "Def":  "3",
+               "Res":  "6",
+               "Arm":  "1",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_3094",
+    "Name":  "Rider (8)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "1",
+               "Off":  "2",
+               "Str":  "2",
+               "AP":  "0",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-bow",
+               "Info":  "(4+)"
+             },
+             {
+               "Id":  "rulebook-lance"
+             },
+             {
+               "Id":  "rule_tag_goblin"
+             }
+           ]
   }
 ]

--- a/WDS/Saurian Ancients/modifiedunit.json
+++ b/WDS/Saurian Ancients/modifiedunit.json
@@ -27,6 +27,16 @@
         "NewUnitId":  "68357f78790d8280c4b2533a_alpha_carnosaur"
     },
     {
+        "OptionId":  "db3e6129-f0eb-44db-b130-0e52f402dbd3",
+        "UnitId":  "68357f78790d8280c4b2533a",
+        "NewProfileId":  "b762d243-8937-4fc7-ae59-313fb77b57fb-rex"
+    },
+    {
+        "OptionId":  "db3e6129-f0eb-44db-b130-0e52f402dbd3",
+        "UnitId":  "68357f78790d8280c4b2533a_alpha_carnosaur",
+        "NewProfileId":  "b762d243-8937-4fc7-ae59-313fb77b57fb-rex"
+    },
+    {
         "OptionId":  "2ab66449-faa9-4605-8901-8f3f83b3cb87",
         "UnitId":  "68357f78790d8280c4b25137"        
     },
@@ -234,10 +244,6 @@
         "UnitId":  "68357f78790d8280c4b25137"
     },
     {
-        "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
-        "UnitId":  "68357f78790d8280c4b25137"
-    },
-    {
         "OptionId":  "5800451b-99bb-4f0a-a941-13c9e95cc2ab",
         "UnitId":  "68357f79790d8280c4b254c7"
     },
@@ -275,10 +281,6 @@
     },
     {
         "OptionId":  "ccdca7f5-8526-4115-a69d-e6a018d10e5f",
-        "UnitId":  "68357f7c790d8280c4b256b2"
-    },
-    {
-        "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
         "UnitId":  "68357f7c790d8280c4b256b2"
     },
     {
@@ -335,11 +337,13 @@
     },
     {
         "OptionId":  "ff85cb96-0770-4fc8-a909-f64d1e1fc09e",
-        "UnitId":  "68357f7b790d8280c4b25621"
+        "UnitId":  "68357f7b790d8280c4b25621",
+        "NewProfileId":  "68357f7b790d8280c4b25623_great_protector"
     },
     {
         "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
-        "UnitId":  "68357f7b790d8280c4b25621"
+        "UnitId":  "68357f7b790d8280c4b25621",
+        "NewProfileId":  "68357f7b790d8280c4b25623_venomous_fortress"
     },
     {
         "OptionId":  "68bdd76a-7c11-41c8-b9fc-f6923aa9c474",
@@ -371,10 +375,6 @@
     },
     {
         "OptionId":  "ccdca7f5-8526-4115-a69d-e6a018d10e5f",
-        "UnitId":  "68357f7c790d8280c4b256c5"
-    },
-    {
-        "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
         "UnitId":  "68357f7c790d8280c4b256c5"
     },
     {
@@ -478,10 +478,6 @@
         "UnitId":  "68357f78790d8280c4b25137_mountain_pteradon"
     },
     {
-        "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
-        "UnitId":  "68357f78790d8280c4b25137_mountain_pteradon"
-    },
-    {
         "OptionId":  "bd495621-e26a-4acc-8af6-3691036cc44c",
         "UnitId":  "68357f78790d8280c4b25137_pouakai_sky_tyrant"
     },
@@ -526,10 +522,6 @@
         "UnitId":  "68357f78790d8280c4b25137_pouakai_sky_tyrant"
     },
     {
-        "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
-        "UnitId":  "68357f78790d8280c4b25137_pouakai_sky_tyrant"
-    },
-    {
         "OptionId":  "bd495621-e26a-4acc-8af6-3691036cc44c",
         "UnitId":  "68357f78790d8280c4b25137_taurosaur"
     },
@@ -571,10 +563,6 @@
     },
     {
         "OptionId":  "ccdca7f5-8526-4115-a69d-e6a018d10e5f",
-        "UnitId":  "68357f78790d8280c4b25137_taurosaur"
-    },
-    {
-        "OptionId":  "510182ec-c90b-4fbf-8221-af9232712bc4",
         "UnitId":  "68357f78790d8280c4b25137_taurosaur"
     },
     {

--- a/WDS/Saurian Ancients/options.json
+++ b/WDS/Saurian Ancients/options.json
@@ -15,6 +15,11 @@
     "Type": 0
   },
   {
+    "Id": "db3e6129-f0eb-44db-b130-0e52f402dbd3",
+    "Name": "Rex",
+    "Type": 3
+  },
+  {
     "Id": "7f256b1a-23cf-4329-a9f7-d431715fd3e8",
     "Name": "Mountain Pteradon",
     "Type": 0
@@ -257,22 +262,12 @@
   {
     "Id": "ff85cb96-0770-4fc8-a909-f64d1e1fc09e",
     "Name": "Great Protector",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "sa-great_protector"
-      }
-    ]
+    "Type": 3
   },
   {
     "Id": "510182ec-c90b-4fbf-8221-af9232712bc4",
     "Name": "Venomous Fortress",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "sa-venomous_fortress"
-      }
-    ]
+    "Type": 3
   },
   {
     "Id": "bfc137c7-ea43-4a3f-aba3-3a1b3d4f57ec",

--- a/WDS/Saurian Ancients/profiles.json
+++ b/WDS/Saurian Ancients/profiles.json
@@ -171,6 +171,29 @@
     ]
   },
   {
+    "Id": "b762d243-8937-4fc7-ae59-313fb77b57fb-rex",
+    "Name": "Tegu Veteran on Alpha Carnosaur Rex",
+    "Type": "Profile",
+    "BaseId": "14",
+    "Children": [
+      {
+        "Id": "statline_1111"
+      },
+      {
+        "Id": "statline_3112"
+      },
+      {
+        "Id": "statline_1107"
+      },
+      {
+        "Id": "statline_1113"
+      },
+      {
+        "Id": "sa-rex"
+      }
+    ]
+  },
+  {
     "Id": "68357f78790d8280c4b25137",
     "Name": "Skink Veteran",
     "Type": "Profile",
@@ -460,6 +483,52 @@
       },
       {
         "Id": "statline_1162"
+      }
+    ]
+  },
+  {
+    "Id": "68357f7b790d8280c4b25623_great_protector",
+    "Name": "Thyroscutus Herd - Great Protector",
+    "Type": "Profile",
+    "BaseId": "2",
+    "Children": [
+      {
+        "Id": "statline_3160"
+      },
+      {
+        "Id": "statline_1161"
+      },
+      {
+        "Id": "statline_1125"
+      },
+      {
+        "Id": "statline_1162"
+      },
+      {
+        "Id": "sa-great_protector"
+      }
+    ]
+  },
+  {
+    "Id": "68357f7b790d8280c4b25623_venomous_fortress",
+    "Name": "Thyroscutus Herd - Venomous Fortress",
+    "Type": "Profile",
+    "BaseId": "10",
+    "Children": [
+      {
+        "Id": "statline_4160"
+      },
+      {
+        "Id": "statline_1161"
+      },
+      {
+        "Id": "statline_4125"
+      },
+      {
+        "Id": "statline_1162"
+      },
+      {
+        "Id": "sa-venomous_fortress"
       }
     ]
   },

--- a/WDS/Saurian Ancients/statlines.json
+++ b/WDS/Saurian Ancients/statlines.json
@@ -575,6 +575,18 @@
              }
   },
   {
+    "Id":  "statline_3112",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "8",
+               "Def":  "3",
+               "Res":  "6",
+               "Arm":  "4",
+               "Aeg":  "-"
+             }
+  },
+  {
     "Id":  "statline_1113",
     "Name":  "Alpha Carnosaur",
     "Type":  "Statline",
@@ -1730,6 +1742,87 @@
              },
              {
                "Id":  "rule_tag_mount"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3160",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Cha":  "5",
+               "Mob":  "5",
+               "Dis":  "6",
+               "Hgt":  "4",
+               "Rsr":  "-"
+             },
+    "Children":  [
+             {
+               "Id":  "sa-communal_bond"
+             },
+             {
+               "Id":  "rulebook-exclusive",
+               "Info":  "(Tegu Warriors)"
+             },
+             {
+               "Id":  "rulebook-fearless"
+             },
+             {
+               "Id":  "rulebook-swiftstride"
+             },
+             {
+               "Id":  "rulebook-war_platform"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_4160",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Cha":  "5",
+               "Mob":  "5",
+               "Dis":  "6",
+               "Hgt":  "4",
+               "Rsr":  "-"
+             },
+    "Children":  [
+             {
+               "Id":  "sa-communal_bond"
+             },
+             {
+               "Id":  "rulebook-exclusive",
+               "Info":  "(Skink Warriors, Skink Hunters)"
+             },
+             {
+               "Id":  "rulebook-fearless"
+             },
+             {
+               "Id":  "rulebook-swiftstride"
+             },
+             {
+               "Id":  "rulebook-war_platform"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_4125",
+    "Name":  "Skink Rider (10)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "1",
+               "Off":  "2",
+               "Str":  "3",
+               "AP":  "0",
+               "Agi":  "3"
+             },
+    "Children":  [
+             {
+               "Id":  "sa-poisoned_javelin",
+               "Info":  "(4+)"
+             },
+             {
+               "Id":  "rule_tag_skink"
              }
            ]
   },

--- a/WDS/Undying Dynasties/modifiedunit.json
+++ b/WDS/Undying Dynasties/modifiedunit.json
@@ -10,6 +10,16 @@
         "NewUnitId":  "68357f84790d8280c4b25ec3_skeleton_chariot"
     },
     {
+        "OptionId":  "fbd8b368-7860-421f-abf7-f11962e6592f",
+        "UnitId":  "68357f84790d8280c4b25ec3",
+        "NewProfileId":  "68357f84790d8280c4b25ec3_chariot_of_nephet_ra"
+    },
+    {
+        "OptionId":  "fbd8b368-7860-421f-abf7-f11962e6592f",
+        "UnitId":  "68357f84790d8280c4b25ec3_skeleton_chariot",
+        "NewProfileId":  "68357f84790d8280c4b25ec3_chariot_of_nephet_ra"
+    },
+    {
         "OptionId":  "05d704e9-90c9-43b2-ba65-424f85923341",
         "UnitId":  "68357f84790d8280c4b25ec3",
         "NewUnitId":  "68357f84790d8280c4b25ec3_sha_guardian"
@@ -23,6 +33,16 @@
         "OptionId":  "fe5d9783-dc3b-4053-8765-2474f603c407",
         "UnitId":  "68357f84790d8280c4b2602b",
         "NewUnitId":  "68357f84790d8280c4b2602b_skeleton_chariot"
+    },
+    {
+        "OptionId":  "fbd8b368-7860-421f-abf7-f11962e6592f",
+        "UnitId":  "68357f84790d8280c4b2602b",
+        "NewProfileId":  "68357f84790d8280c4b2602b_chariot_of_nephet_ra"
+    },
+    {
+        "OptionId":  "fbd8b368-7860-421f-abf7-f11962e6592f",
+        "UnitId":  "68357f84790d8280c4b2602b_skeleton_chariot",
+        "NewProfileId":  "68357f84790d8280c4b2602b_chariot_of_nephet_ra"
     },
     {
         "OptionId":  "9f407948-48eb-45e9-9747-8bc6f864e514",

--- a/WDS/Undying Dynasties/options.json
+++ b/WDS/Undying Dynasties/options.json
@@ -10,6 +10,11 @@
     "Type": 0
   },
   {
+    "Id": "fbd8b368-7860-421f-abf7-f11962e6592f",
+    "Name": "Chariot of Nephet-Râ",
+    "Type": 3
+  },
+  {
     "Id": "05d704e9-90c9-43b2-ba65-424f85923341",
     "Name": "Sha Guardian",
     "Type": 0

--- a/WDS/Undying Dynasties/profiles.json
+++ b/WDS/Undying Dynasties/profiles.json
@@ -60,6 +60,32 @@
     ]
   },
   {
+    "Id": "68357f84790d8280c4b25ec3_chariot_of_nephet_ra",
+    "Name": "Pharaoh on Skeleton Chariot of Nephet-Râ",
+    "Type": "Profile",
+    "BaseId": "12",
+    "Children": [
+      {
+        "Id": "statline_3295"
+      },
+      {
+        "Id": "statline_1296"
+      },
+      {
+        "Id": "statline_1291"
+      },
+      {
+        "Id": "statline_3297"
+      },
+      {
+        "Id": "statline_1298"
+      },
+      {
+        "Id": "ud-chariot_of_nephet_ra"
+      }
+    ]
+  },
+  {
     "Id": "8361dbfe-f13a-48ba-9155-3edfdba97609",
     "Name": "Pharaoh on Sha Guardian",
     "Type": "Profile",
@@ -136,6 +162,32 @@
       },
       {
         "Id": "statline_1311"
+      }
+    ]
+  },
+  {
+    "Id": "68357f84790d8280c4b2602b_chariot_of_nephet_ra",
+    "Name": "Nomarch on Skeleton Chariot of Nephet-Râ",
+    "Type": "Profile",
+    "BaseId": "12",
+    "Children": [
+      {
+        "Id": "statline_3308"
+      },
+      {
+        "Id": "statline_1309"
+      },
+      {
+        "Id": "statline_1304"
+      },
+      {
+        "Id": "statline_3310"
+      },
+      {
+        "Id": "statline_1311"
+      },
+      {
+        "Id": "ud-chariot_of_nephet_ra"
       }
     ]
   },

--- a/WDS/Undying Dynasties/statlines.json
+++ b/WDS/Undying Dynasties/statlines.json
@@ -215,7 +215,7 @@
                "Id":  "rule_tag_skeleton"
              }
            ]
-  },
+  },  
   {
     "Id":  "statline_1298",
     "Name":  "Chassis",
@@ -234,6 +234,70 @@
              },
              {
                "Id":  "rule_tag_construct"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3295",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Cha":  "8",
+               "Mob":  "5",
+               "Dis":  "9",
+               "Hgt":  "4",
+               "Rsr":  "-"
+             },
+    "Children":  [
+             {
+               "Id":  "ud-autonomous"
+             },
+             {
+               "Id":  "rulebook-disciplined"
+             },
+             {
+               "Id":  "rulebook-fearless"
+             },
+             {
+               "Id":  "rulebook-fly"
+             },
+             {
+               "Id":  "rulebook-light_troops"
+             },
+             {
+               "Id":  "rulebook-solitary"
+             },
+             {
+               "Id":  "rulebook-swiftstride"
+             },
+             {
+               "Id":  "rulebook-undead"
+             },
+             {
+               "Id":  "ud-undying_will"
+             },
+             {
+               "Id":  "rulebook-unstable"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3297",
+    "Name":  "Skeletal Horse (4)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "1",
+               "Off":  "2",
+               "Str":  "3",
+               "AP":  "0",
+               "Agi":  "2"
+             },
+    "Children":  [
+             {
+               "Id":  "rule_tag_mount"
+             },
+             {
+               "Id":  "rule_tag_skeleton"
              }
            ]
   },
@@ -549,6 +613,67 @@
              },
              {
                "Id":  "rule_tag_construct"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3308",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Cha":  "8",
+               "Mob":  "5",
+               "Dis":  "8",
+               "Hgt":  "4",
+               "Rsr":  "1"
+             },
+    "Children":  [
+             {
+               "Id":  "ud-autonomous"
+             },
+             {
+               "Id":  "rulebook-fly"
+             },
+             {
+               "Id":  "rulebook-fearless"
+             },
+             {
+               "Id":  "rulebook-fly"
+             },
+             {
+               "Id":  "rulebook-light_troops"
+             },
+             {
+               "Id":  "rulebook-solitary"
+             },
+             {
+               "Id":  "rulebook-swiftstride"
+             },
+             {
+               "Id":  "rulebook-undead"
+             },
+             {
+               "Id":  "rulebook-unstable"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3310",
+    "Name":  "Skeletal Horse (4)",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "1",
+               "Off":  "2",
+               "Str":  "3",
+               "AP":  "0",
+               "Agi":  "2"
+             },
+    "Children":  [
+             {
+               "Id":  "rule_tag_mount"
+             },
+             {
+               "Id":  "rule_tag_skeleton"
              }
            ]
   },

--- a/WDS/Vampire Covenant/modifiedunit.json
+++ b/WDS/Vampire Covenant/modifiedunit.json
@@ -1,5 +1,15 @@
 ﻿[
     {
+        "OptionId":  "1bd8e389-071e-46ae-8c07-dacad98e7ae6",
+        "UnitId":  "68357f8b790d8280c4b26614",
+        "NewProfileId":  "68357f8b790d8280c4b26614_bestial_bulk"
+    },
+    {
+        "OptionId":  "1bd8e389-071e-46ae-8c07-dacad98e7ae6",
+        "UnitId":  "68357f8c790d8280c4b26a24",
+        "NewProfileId":  "68357f8c790d8280c4b26a24_bestial_bulk"
+    },
+    {
         "OptionId":  "0935a016-e6a4-4b16-a63f-7b574b7bab36",
         "UnitId":  "68357f8b790d8280c4b26614",
         "NewUnitId":  "68357f8b790d8280c4b26614_skeletal_steed"
@@ -13,6 +23,16 @@
         "OptionId":  "0173a441-7cf2-4293-b88a-7a3bfeb498ab",
         "UnitId":  "68357f8b790d8280c4b26614",
         "NewUnitId":  "68357f8b790d8280c4b26614_monstrous_revenant"
+    },
+    {
+        "OptionId":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "UnitId":  "68357f8b790d8280c4b26614",
+        "NewProfileId":  "68357f8b790d8280c4b26614_great_monstruous_revenant"
+    },
+    {
+        "OptionId":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "UnitId":  "68357f8b790d8280c4b26614_monstrous_revenant",
+        "NewProfileId":  "68357f8b790d8280c4b26614_great_monstruous_revenant"
     },
     {
         "OptionId":  "1e83bb97-324b-48b4-ae19-1e7fc3542921",
@@ -50,6 +70,16 @@
         "NewUnitId":  "68357f8c790d8280c4b26a24_monstrous_revenant"
     },
     {
+        "OptionId":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "UnitId":  "68357f8c790d8280c4b26a24",
+        "NewProfileId":  "68357f8c790d8280c4b26a24_great_monstruous_revenant"
+    },
+    {
+        "OptionId":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "UnitId":  "68357f8c790d8280c4b26a24_monstruous_revenant",
+        "NewProfileId":  "68357f8c790d8280c4b26a24_great_monstruous_revenant"
+    },
+    {
         "OptionId":  "1e83bb97-324b-48b4-ae19-1e7fc3542921",
         "UnitId":  "68357f8c790d8280c4b26a24",
         "NewUnitId":  "68357f8c790d8280c4b26a24_court_of_the_damned"
@@ -63,6 +93,16 @@
         "OptionId":  "0173a441-7cf2-4293-b88a-7a3bfeb498ab",
         "UnitId":  "68357f8d790d8280c4b26ccc",
         "NewUnitId":  "68357f8d790d8280c4b26ccc_monstrous_revenant"
+    },
+    {
+        "OptionId":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "UnitId":  "68357f8d790d8280c4b26ccc",
+        "NewProfileId":  "68357f8d790d8280c4b26ccc_great_monstruous_revenant"
+    },
+    {
+        "OptionId":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "UnitId":  "668357f8d790d8280c4b26ccc_monstrous_revenant",
+        "NewProfileId":  "68357f8d790d8280c4b26ccc_great_monstruous_revenant"
     },
     {
         "OptionId":  "9e7cc8b1-af28-4346-b9b2-fd92ca8092a9",

--- a/WDS/Vampire Covenant/options.json
+++ b/WDS/Vampire Covenant/options.json
@@ -15,6 +15,11 @@
         "Type":  0
     },
     {
+        "Id":  "9c5aa307-fa77-4512-8943-e8b15886e4e1",
+        "Name":  "Great Monstruous Revenant",
+        "Type":  3
+    },
+    {
         "Id":  "1e83bb97-324b-48b4-ae19-1e7fc3542921",
         "Name":  "Court of the Damned",
         "Type":  0
@@ -39,7 +44,12 @@
         "Name":  "Cadaver Wagon",
         "Type":  0
     },
-  {
+    {
+        "Id":  "1bd8e389-071e-46ae-8c07-dacad98e7ae6",
+        "Name":  "Bestial Bulk",
+        "Type":  3
+    },
+    {
         "Id":  "6226316e-2ed9-4af6-b7d5-51a34b236990",
         "Name":  "Extended Chassis",
         "Type":  3

--- a/WDS/Vampire Covenant/profiles.json
+++ b/WDS/Vampire Covenant/profiles.json
@@ -17,6 +17,26 @@
     ]
   },
   {
+    "Id": "68357f8b790d8280c4b26614_bestial_bulk",
+    "Name": "Vampire Count - Bestial Bulk",
+    "Type": "Profile",
+    "BaseId": "4",
+    "Children": [
+      {
+        "Id": "statline_3394"
+      },
+      {
+        "Id": "statline_3395"
+      },
+      {
+        "Id": "statline_3396"
+      },
+      {
+        "Id": "vc-bestial_bulk"
+      }
+    ]
+  },
+  {
     "Id": "fa697a3b-8c97-41f6-962f-9ef1ffc02a06",
     "Name": "Vampire Count on Skeletal Steed",
     "Type": "Profile",
@@ -73,6 +93,29 @@
       },
       {
         "Id": "statline_1405"
+      }
+    ]
+  },
+  {
+    "Id": "68357f8b790d8280c4b26614_great_monstruous_revenant",
+    "Name": "Vampire Count on Great Monstrous Revenant",
+    "Type": "Profile",
+    "BaseId": "10",
+    "Children": [
+      {
+        "Id": "statline_1403"
+      },
+      {
+        "Id": "statline_1404"
+      },
+      {
+        "Id": "statline_1396"
+      },
+      {
+        "Id": "statline_3405"
+      },
+      {
+        "Id": "vc-great_monstrous_revenant"
       }
     ]
   },
@@ -180,6 +223,26 @@
     ]
   },
   {
+    "Id": "68357f8c790d8280c4b26a24_bestial_bulk",
+    "Name": "Vampire Courtier - Bestial Bulk",
+    "Type": "Profile",
+    "BaseId": "4",
+    "Children": [
+      {
+        "Id": "statline_3419"
+      },
+      {
+        "Id": "statline_3420"
+      },
+      {
+        "Id": "statline_3421"
+      },
+      {
+        "Id": "vc-bestial_bulk"
+      }
+    ]
+  },
+  {
     "Id": "34657fff-38c4-4c53-b199-be941b45eca5",
     "Name": "Vampire Courtier on Skeletal Steed",
     "Type": "Profile",
@@ -236,6 +299,29 @@
       },
       {
         "Id": "statline_1405"
+      }
+    ]
+  },
+  {
+    "Id": "68357f8c790d8280c4b26a24_great_monstruous_revenant",
+    "Name": "Vampire Courtier on Great Monstrous Revenant",
+    "Type": "Profile",
+    "BaseId": "10",
+    "Children": [
+      {
+        "Id": "statline_1426"
+      },
+      {
+        "Id": "statline_1427"
+      },
+      {
+        "Id": "statline_1421"
+      },
+      {
+        "Id": "statline_3405"
+      },
+      {
+        "Id": "vc-great_monstrous_revenant"
       }
     ]
   },
@@ -319,6 +405,29 @@
       },
       {
         "Id": "statline_1405"
+      }
+    ]
+  },
+  {
+    "Id": "68357f8d790d8280c4b26ccc_great_monstruous_revenant",
+    "Name": "Necromancer on Great Monstrous Revenant",
+    "Type": "Profile",
+    "BaseId": "10",
+    "Children": [
+      {
+        "Id": "statline_1434"
+      },
+      {
+        "Id": "statline_1435"
+      },
+      {
+        "Id": "statline_1431"
+      },
+      {
+        "Id": "statline_3405"
+      },
+      {
+        "Id": "vc-great_monstrous_revenant"
       }
     ]
   },

--- a/WDS/Vampire Covenant/statlines.json
+++ b/WDS/Vampire Covenant/statlines.json
@@ -69,6 +69,78 @@
            ]
   },
   {
+    "Id":  "statline_3394",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Cha":  "6",
+               "Mob":  "6",
+               "Dis":  "9",
+               "Hgt":  "3",
+               "Rsr":  "1"
+             },
+    "Children":  [
+             {
+               "Id":  "vc-autonomous"
+             },
+             {
+               "Id":  "vc-awaken",
+               "Info":  "(Zombies)"
+             },
+             {
+               "Id":  "rulebook-fearless"
+             },
+             {
+               "Id":  "rulebook-light_troops"
+             },
+             {
+               "Id":  "rulebook-undead"
+             },
+             {
+               "Id":  "rulebook-unstable"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3395",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "3",
+               "Def":  "7",
+               "Res":  "6",
+               "Arm":  "2",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_3396",
+    "Name":  "Vampire Count",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "5",
+               "Off":  "7",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "7"
+             },
+    "Children":  [
+             {
+               "Id":  "vc-unholy_appetite"
+             },
+             {
+               "Id":  "vc-vampiric",
+               "Info":  "(6+)"
+             },
+             {
+               "Id":  "rule_tag_metal_armour"
+             },
+             {
+               "Id":  "rule_tag_vampire"
+             }
+           ]
+  },
+  {
     "Id":  "statline_1397",
     "Name":  "",
     "Type":  "Statline",
@@ -291,6 +363,39 @@
              {
                "Id":  "rulebook-stomp_attack",
                "Info":  "(1)"
+             },
+             {
+               "Id":  "rule_tag_beast"
+             },
+             {
+               "Id":  "rule_tag_mount"
+             },
+             {
+               "Id":  "rule_tag_zombie"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3405",
+    "Name":  "Monstrous Revenant",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "4",
+               "Off":  "4",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "2"
+             },
+    "Children":  [
+             {
+               "Id":  "rulebook-lethal_strike"
+             },
+             {
+               "Id":  "rulebook-poison_attacks"
+             },
+             {
+               "Id":  "rulebook-stomp_attack",
+               "Info":  "(D3)"
              },
              {
                "Id":  "rule_tag_beast"
@@ -812,6 +917,78 @@
                "Agi":  "6"
              },
     "Children":  [
+             {
+               "Id":  "vc-vampiric",
+               "Info":  "(6+)"
+             },
+             {
+               "Id":  "rule_tag_metal_armour"
+             },
+             {
+               "Id":  "rule_tag_vampire"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3419",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Cha":  "6",
+               "Mob":  "6",
+               "Dis":  "8",
+               "Hgt":  "3",
+               "Rsr":  "1"
+             },
+    "Children":  [
+             {
+               "Id":  "vc-autonomous"
+             },
+             {
+               "Id":  "vc-awaken",
+               "Info":  "(Zombies)"
+             },
+             {
+               "Id":  "rulebook-fearless"
+             },
+             {
+               "Id":  "rulebook-light_troops"
+             },
+             {
+               "Id":  "rulebook-undead"
+             },
+             {
+               "Id":  "rulebook-unstable"
+             }
+           ]
+  },
+  {
+    "Id":  "statline_3420",
+    "Name":  "",
+    "Type":  "Statline",
+    "Attributes":  {
+               "HP":  "3",
+               "Def":  "6",
+               "Res":  "5",
+               "Arm":  "2",
+               "Aeg":  "-"
+             }
+  },
+  {
+    "Id":  "statline_3421",
+    "Name":  "Vampire Courtier",
+    "Type":  "Statline",
+    "Attributes":  {
+               "Att":  "4",
+               "Off":  "6",
+               "Str":  "5",
+               "AP":  "2",
+               "Agi":  "6"
+             },
+    "Children":  [
+             {
+               "Id":  "vc-unholy_appetite"
+             },
              {
                "Id":  "vc-vampiric",
                "Info":  "(6+)"

--- a/WDS/manifest.json
+++ b/WDS/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version":  52,
+    "version":  53,
     "files":  [
                   "bases.json",
                   "cards.json",

--- a/WDS/rules.json
+++ b/WDS/rules.json
@@ -5478,7 +5478,7 @@
     "Description": "The model’s <u><link=\"rulebook-resurrect\">Resurrected</link></u> value is <b>set</b> to 1, and it gains <u><link=\"rulebook-aegis\">Aegis</link></u> (3+ against non-<u><link=\"rulebook-magical_attacks\">Magical Attacks</link></u>), <u><link=\"rulebook-aegis\">Aegis (5+)</link></u>, <u><link=\"rulebook-ghost_step\">Ghost Step</link></u>, <u><link=\"rulebook-magical_attacks\">Magical Attacks</link></u>, <i>Spirit</i>, and loses <u><link=\"rulebook-hard_target\">Hard Target (1)</link></u> and <u><link=\"rulebook-skirmisher\">Skirmisher</link></u>."
   },
   {
-    "Id": "ud-chariot_of_nephetr",
+    "Id": "ud-chariot_of_nephet_ra",
     "Name": "Chariot of Nephet-Râ",
     "Type": "Rule",
     "Description": "The model’s base size is changed to 100×100 mm, it gains two additional ‘Skeletal Horse’ model parts, <u><link=\"rulebook-fly\">Fly</link></u>, <u><link=\"rulebook-solitary\">Solitary</link></u> and loses <u><link=\"rulebook-exclusive\">Exclusive</link></u>."


### PR DESCRIPTION
3rd batch update:

🚀03/ DE / Characters / Manticore / Extraordinary Specimen
🚀10/ OnG / Guardian Behemoth / Immense Bulk
🚀11/ SA / Alpha Carnosaur / Rex
🚀11/ SA / Thyroscutus Herd / Venomous Fortress
🚀13/ UD / Pharaoh & Nomarch / Skeleton Chariot / Chariot of Nephet-Râ
🚀14/ VC / Vampires / Bestial Bulk
🚀14/ VC / Vampires / Great Monstrous Revenant

have verified all implemented modifications on **WH TEST**:
..
<img width="1723" height="808" alt="image" src="https://github.com/user-attachments/assets/c6f8c2e7-7d15-4386-94fb-04c172380c92" />

**PR** to be reviewed and **MR** to be implemented into pre-production-**WDSv2** branch and afterwards pushed to **WH PROD**