### PR TITLE
AB / OnG / Gogtuk Initiates / neither mounts nor options available  

### DIFF
--- a/WDS/Orcs and Goblins/modifiedunit.json
+++ b/WDS/Orcs and Goblins/modifiedunit.json
@@ -130,21 +130,6 @@
         "NewUnitId":  "68357f70790d8280c4b248ca_beastie"
     },
     {
-        "OptionId":  "option_1753954225508",
-        "UnitId":  "68357f70790d8280c4b248ca",
-        "NewUnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "option_1753954253573",
-        "UnitId":  "68357f70790d8280c4b248ca",
-        "NewUnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "option_1753954277100",
-        "UnitId":  "68357f70790d8280c4b248ca",
-        "NewUnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
         "OptionId":  "2fa68d57-8c91-4d2f-92be-4cc3e7f9d3b1",
         "UnitId":  "a2b8d1f3701d5c8e4a7e3d905",
         "NewUnitId":  "a2b8d1f3701d5c8e4a7e3d905_tabetha_41"
@@ -370,50 +355,6 @@
         "OptionId":  "3630abe9-3a21-4b6d-90ad-8e01a9e65a33",
         "UnitId":  "68357f6f790d8280c4b2475e",
         "NewProfileID":  "5f5c1cfb-8bfb-49d6-ae8e-282ca09a785b_huntsman_spider"
-    },
-    {
-        "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "841df456-d75b-4a12-96aa-2997c44c9f16",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "8f4e5e87-1cea-497f-a088-284be1ecf107",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "828fbbe6-3470-4532-b909-d75b0053e604",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "42660827-4ea4-4491-8701-750aa2c2e0da",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "c475c768-a592-4f1c-bd70-ff1009cbe523",
-        "UnitId":  "68357f70790d8280c4b248ca"
-    },
-    {
-        "OptionId":  "fb35f3d2-2488-4233-acd8-4ec40d418d69",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "d2e9f4a1-7c8f-4a2d-bf7d-19b74e3f6a9b",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
     },
     {
         "OptionId":  "6d8b4a47-81bd-4a53-a34d-91a6e0d109ba",
@@ -729,183 +670,44 @@
     },
     {
         "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
+        "UnitId":  "68357f70790d8280c4b248ca",
+        "NewUnitId":  "68357f70790d8280c4b248ca_creepy_crawlies"
+    },
+    {
+        "OptionId":  "68357f70790d8280c4b248ca_headhunter",
+        "UnitId":  "68357f70790d8280c4b248ca"
+    },
+    {
+        "OptionId":  "68357f70790d8280c4b248ca_mauler",
+        "UnitId":  "68357f70790d8280c4b248ca"
+    },
+    {
+        "OptionId":  "68357f70790d8280c4b248ca_netter",
+        "UnitId":  "68357f70790d8280c4b248ca"
+    },
+    {
+        "OptionId":  "68357f70790d8280c4b248ca_headhunter",
         "UnitId":  "68357f70790d8280c4b248ca_beastie"
     },
     {
-        "OptionId":  "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
+        "OptionId":  "68357f70790d8280c4b248ca_mauler",
         "UnitId":  "68357f70790d8280c4b248ca_beastie"
     },
     {
-        "OptionId":  "841df456-d75b-4a12-96aa-2997c44c9f16",
+        "OptionId":  "68357f70790d8280c4b248ca_netter",
         "UnitId":  "68357f70790d8280c4b248ca_beastie"
     },
     {
-        "OptionId":  "8f4e5e87-1cea-497f-a088-284be1ecf107",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie"
+        "OptionId":  "68357f70790d8280c4b248ca_headhunter",
+        "UnitId":  "68357f70790d8280c4b248ca_creepy_crawlies"
     },
     {
-        "OptionId":  "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie"
+        "OptionId":  "68357f70790d8280c4b248ca_mauler",
+        "UnitId":  "68357f70790d8280c4b248ca_creepy_crawlies"
     },
     {
-        "OptionId":  "828fbbe6-3470-4532-b909-d75b0053e604",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie"
-    },
-    {
-        "OptionId":  "42660827-4ea4-4491-8701-750aa2c2e0da",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie"
-    },
-    {
-        "OptionId":  "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie"
-    },
-    {
-        "OptionId":  "c475c768-a592-4f1c-bd70-ff1009cbe523",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie"
-    },
-    {
-        "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "841df456-d75b-4a12-96aa-2997c44c9f16",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "8f4e5e87-1cea-497f-a088-284be1ecf107",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "828fbbe6-3470-4532-b909-d75b0053e604",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "42660827-4ea4-4491-8701-750aa2c2e0da",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "c475c768-a592-4f1c-bd70-ff1009cbe523",
-        "UnitId":  "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies"
-    },
-    {
-        "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "841df456-d75b-4a12-96aa-2997c44c9f16",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "8f4e5e87-1cea-497f-a088-284be1ecf107",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "828fbbe6-3470-4532-b909-d75b0053e604",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "42660827-4ea4-4491-8701-750aa2c2e0da",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "c475c768-a592-4f1c-bd70-ff1009cbe523",
-        "UnitId":  "68357f70790d8280c4b248ca_netter"
-    },
-    {
-        "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "841df456-d75b-4a12-96aa-2997c44c9f16",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "8f4e5e87-1cea-497f-a088-284be1ecf107",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "828fbbe6-3470-4532-b909-d75b0053e604",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "42660827-4ea4-4491-8701-750aa2c2e0da",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "c475c768-a592-4f1c-bd70-ff1009cbe523",
-        "UnitId":  "68357f70790d8280c4b248ca_mauler"
-    },
-    {
-        "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "841df456-d75b-4a12-96aa-2997c44c9f16",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "8f4e5e87-1cea-497f-a088-284be1ecf107",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "828fbbe6-3470-4532-b909-d75b0053e604",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "42660827-4ea4-4491-8701-750aa2c2e0da",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
-    },
-    {
-        "OptionId":  "c475c768-a592-4f1c-bd70-ff1009cbe523",
-        "UnitId":  "68357f70790d8280c4b248ca_headhunter"
+        "OptionId":  "68357f70790d8280c4b248ca_netter",
+        "UnitId":  "68357f70790d8280c4b248ca_creepy_crawlies"
     },
     {
         "OptionId":  "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",

--- a/WDS/Orcs and Goblins/options.json
+++ b/WDS/Orcs and Goblins/options.json
@@ -40,36 +40,6 @@
     "Type": 0
   },
   {
-    "Id": "option_1753954225508",
-    "Name": "Netter",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "rule_netter_e706a757"
-      }
-    ]
-  },
-  {
-    "Id": "option_1753954253573",
-    "Name": "Mauler",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "rule_mauler_b8bbef27"
-      }
-    ]
-  },
-  {
-    "Id": "option_1753954277100",
-    "Name": "Headhunter",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "rule_headhunter_2bbc3d51"
-      }
-    ]
-  },
-  {
     "Id": "65a8569e-799f-4d34-912f-d4c6069b982a",
     "Name": "Goblin Gardens",
     "Type": 7,
@@ -217,32 +187,7 @@
   {
     "Id": "3f932d2f-4aed-42fb-b2eb-44405b9fd9bc",
     "Name": "Creepy-Crawlies",
-    "Type": 1,
-    "ItemsToAdd": [
-      {
-        "Id": "ong-creepycrawlies"
-      }
-    ]
-  },
-  {
-    "Id": "c9cdb798-5a28-4bd2-bcb9-52bb83d09816",
-    "Name": "Forest Goblin",
-    "Type": 1
-  },
-  {
-    "Id": "f2b5a390-ba30-46ad-9323-0e76456bf6a0",
-    "Name": "Headhunter - Beastie",
-    "Type": 1
-  },
-  {
-    "Id": "841df456-d75b-4a12-96aa-2997c44c9f16",
-    "Name": "Headhunter - Creepy",
-    "Type": 1
-  },
-  {
-    "Id": "8f4e5e87-1cea-497f-a088-284be1ecf107",
-    "Name": "Headhunter - On Foot",
-    "Type": 1
+    "Type": 0
   },
   {
     "Id": "3630abe9-3a21-4b6d-90ad-8e01a9e65a33",
@@ -323,28 +268,33 @@
     "Type": 3
   },
   {
-    "Id": "dcf9b797-7abb-423c-9f8a-c54ae3ee19a4",
-    "Name": "Mad Git",
-    "Type": 1
+    "Id": "68357f70790d8280c4b248ca_headhunter",
+    "Name": "Headhunter",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "ong-headhunter"
+      }
+    ]
   },
   {
-    "Id": "828fbbe6-3470-4532-b909-d75b0053e604",
-    "Name": "Mauler - Beastie",
-    "Type": 1
+    "Id": "68357f70790d8280c4b248ca_mauler",
+    "Name": "Mauler",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "ong-mauler"
+      }
+    ]
   },
   {
-    "Id": "42660827-4ea4-4491-8701-750aa2c2e0da",
-    "Name": "Mauler - Creepy",
-    "Type": 1
-  },
-  {
-    "Id": "6d513cbb-a422-4ee4-a0d8-17e3e8cf8ee3",
-    "Name": "Netter - Beastie",
-    "Type": 1
-  },
-  {
-    "Id": "c475c768-a592-4f1c-bd70-ff1009cbe523",
-    "Name": "Netter - Creepy",
-    "Type": 1
+    "Id": "68357f70790d8280c4b248ca_netter",
+    "Name": "Netter",
+    "Type": 1,
+    "ItemsToAdd": [
+      {
+        "Id": "ong-netter"
+      }
+    ]
   }
 ]

--- a/WDS/Orcs and Goblins/profiles.json
+++ b/WDS/Orcs and Goblins/profiles.json
@@ -622,7 +622,7 @@
   },
   {
     "Id": "68357f70790d8280c4b248ca",
-    "Name": "Gogtuk Initiate - Netter",
+    "Name": "Gogtuk Initiate",
     "Type": "Profile",
     "BaseId": "5",
     "Children": [
@@ -638,16 +638,16 @@
     ]
   },
   {
-    "Id": "4b8856ad-0bc8-4d19-a239-297e4b3f751e",
+    "Id": "48707634-56e7-44e7-8d56-91e5251b34f8",
     "Name": "Gogtuk Initiate on Beastie",
     "Type": "Profile",
     "BaseId": "3",
     "Children": [
       {
-        "Id": "statline_980"
+        "Id": "statline_3003"
       },
       {
-        "Id": "statline_981"
+        "Id": "statline_1004"
       },
       {
         "Id": "statline_1005"
@@ -659,55 +659,21 @@
   },
   {
     "Id": "4b8856ad-0bc8-4d19-a239-297e4b3f991e",
-    "Name": "Gogtuk Initiate on Beastie - Creepy-Crawlies",
+    "Name": "Gogtuk Initiate on Creepy-Crawlies",
     "Type": "Profile",
     "BaseId": "3",
     "Children": [
       {
-        "Id": "statline_980"
+        "Id": "statline_4004"
       },
       {
-        "Id": "statline_981"
+        "Id": "statline_1004"
       },
       {
         "Id": "statline_1005"
       },
       {
         "Id": "statline_1006"
-      }
-    ]
-  },
-  {
-    "Id": "68357f70790d8280c4b248cc",
-    "Name": "Gogtuk Initiate - Mauler",
-    "Type": "Profile",
-    "BaseId": "5",
-    "Children": [
-      {
-        "Id": "statline_1007"
-      },
-      {
-        "Id": "statline_1004"
-      },
-      {
-        "Id": "statline_1008"
-      }
-    ]
-  },
-  {
-    "Id": "68357f70790d8280c4b248cb",
-    "Name": "Gogtuk Initiate - Headhunter",
-    "Type": "Profile",
-    "BaseId": "5",
-    "Children": [
-      {
-        "Id": "statline_1009"
-      },
-      {
-        "Id": "statline_1004"
-      },
-      {
-        "Id": "statline_1010"
       }
     ]
   },

--- a/WDS/Orcs and Goblins/statlines.json
+++ b/WDS/Orcs and Goblins/statlines.json
@@ -1750,9 +1750,6 @@
                "Id":  "rulebook-attached"
              },
              {
-               "Id":  "ong-goblin_cunning"
-             },
-             {
                "Id":  "ong-beastie_whisperer"
              },
              {
@@ -1763,13 +1760,16 @@
                "Id":  "rulebook-feigned_flight"
              },
              {
-               "Id":  "rulebook-hit_and_run"
+               "Id":  "ong-goblin_cunning"
              },
              {
                "Id":  "rulebook-hidden"
              },
              {
-               "Id":  "ong-netter"
+               "Id":  "rulebook-hit_and_run"
+             },
+             {
+               "Id":  "rulebook-light_troops"
              },
              {
                "Id":  "ong-unprofessional_courtesy"
@@ -1796,7 +1796,7 @@
   },
   {
     "Id":  "statline_1005",
-    "Name":  "Gogtuk Initiate - Netter",
+    "Name":  "Gogtuk Initiate",
     "Type":  "Statline",
     "Attributes":  {
                "Att":  "2",
@@ -1827,12 +1827,14 @@
                "Id":  "ong-creepycrawlies"
              },
              {
-               "Id":  "rule_tag_construct"
+               "Id":  "rulebook-poison_attacks"
+             },
+             {
+               "Id":  "rule_tag_mount"
              }
            ]
-  },
-  {
-    "Id":  "statline_1007",
+  },  {
+    "Id":  "statline_3003",
     "Name":  "",
     "Type":  "Statline",
     "Attributes":  {
@@ -1866,32 +1868,18 @@
                "Id":  "rulebook-hit_and_run"
              },
              {
+               "Id":  "rulebook-light_troops"
+             },
+             {
+               "Id":  "rulebook-swiftstride"
+             },
+             {
                "Id":  "ong-unprofessional_courtesy"
-             },
-             {
-               "Id":  "rulebook-fury"
              }
            ]
   },
   {
-    "Id":  "statline_1008",
-    "Name":  "Gogtuk Initiate - Mauler",
-    "Type":  "Statline",
-    "Attributes":  {
-               "Att":  "2",
-               "Off":  "4",
-               "Str":  "4",
-               "AP":  "2",
-               "Agi":  "4"
-             },
-    "Children":  [
-             {
-               "Id":  "rulebook-great_weapon"
-             }
-           ]
-  },
-  {
-    "Id":  "statline_1009",
+    "Id":  "statline_4003",
     "Name":  "",
     "Type":  "Statline",
     "Attributes":  {
@@ -1916,6 +1904,9 @@
                "Id":  "rulebook-feigned_flight"
              },
              {
+               "Id":  "rulebook-ghost_step"
+             },
+             {
                "Id":  "ong-goblin_cunning"
              },
              {
@@ -1925,32 +1916,13 @@
                "Id":  "rulebook-hit_and_run"
              },
              {
+               "Id":  "rulebook-light_troops"
+             },
+             {
+               "Id":  "rulebook-swiftstride"
+             },
+             {
                "Id":  "ong-unprofessional_courtesy"
-             },
-             {
-               "Id":  "rulebook-poison_attacks",
-               "Info":  "(Melee and Shooting)"
-             }
-           ]
-  },
-  {
-    "Id":  "statline_1010",
-    "Name":  "Gogtuk Initiate - Headhunter",
-    "Type":  "Statline",
-    "Attributes":  {
-               "Att":  "2",
-               "Off":  "4",
-               "Str":  "4",
-               "AP":  "2",
-               "Agi":  "4"
-             },
-    "Children":  [
-             {
-               "Id":  "rulebook-paired_weapons"
-             },
-             {
-               "Id":  "rulebook-throwing_weapons",
-               "Info":  "(4+, Shots 3)"
              }
            ]
   },

--- a/WDS/Orcs and Goblins/units.json
+++ b/WDS/Orcs and Goblins/units.json
@@ -372,55 +372,19 @@
     "Attributes": {
     },
     "BasicProfileIds": [
-      "4b8856ad-0bc8-4d19-a239-297e4b3f751e"
+      "48707634-56e7-44e7-8d56-91e5251b34f8"
     ],
     "DefaultFront": 1,
     "Formation": 0
   },
   {
-    "Id": "68357f70790d8280c4b248ca_beastie_-_creepy-crawlies",
-    "Name": "Gogtuk Initiate on Beastie - Creepy-Crawlies",
+    "Id": "68357f70790d8280c4b248ca_creepy_crawlies",
+    "Name": "Gogtuk Initiate on Creepy-Crawlies",
     "Type": "Unit",
     "Attributes": {
     },
     "BasicProfileIds": [
       "4b8856ad-0bc8-4d19-a239-297e4b3f991e"
-    ],
-    "DefaultFront": 1,
-    "Formation": 0
-  },
-  {
-    "Id": "68357f70790d8280c4b248ca_netter",
-    "Name": "Gogtuk Initiate - Netter",
-    "Type": "Unit",
-    "Attributes": {
-    },
-    "BasicProfileIds": [
-      "68357f70790d8280c4b248ca"
-    ],
-    "DefaultFront": 1,
-    "Formation": 0
-  },
-  {
-    "Id": "68357f70790d8280c4b248ca_mauler",
-    "Name": "Gogtuk Initiate - Mauler",
-    "Type": "Unit",
-    "Attributes": {
-    },
-    "BasicProfileIds": [
-      "68357f70790d8280c4b248cc"
-    ],
-    "DefaultFront": 1,
-    "Formation": 0
-  },
-  {
-    "Id": "68357f70790d8280c4b248ca_headhunter",
-    "Name": "Gogtuk Initiate - Headhunter",
-    "Type": "Unit",
-    "Attributes": {
-    },
-    "BasicProfileIds": [
-      "68357f70790d8280c4b248cb"
     ],
     "DefaultFront": 1,
     "Formation": 0

--- a/WDS/manifest.json
+++ b/WDS/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version":  57,
+    "version":  58,
     "files":  [
                   "bases.json",
                   "cards.json",


### PR DESCRIPTION
complete rework of unit, mounts and options performed
clean-up of multiple fake/unnecessary options also performed
Gogtuk Initiate is now available in the Create/Unit menu with its 3 Mounts types and its 3 Options types
have verified all implemented modifications on **WH TEST**:
..
<img width="1753" height="918" alt="image" src="https://github.com/user-attachments/assets/a68f053a-3c63-428d-b095-8aa37620caa3" />
..
**PR** to be reviewed and **MR** to be implemented into pre-production-**WDSv2** branch and afterwards pushed to **WH PROD**
